### PR TITLE
In PHP 7.1, some modules would fail with "Uncaught ArgumentCountError…

### DIFF
--- a/classes/AbstractExternalModule.php
+++ b/classes/AbstractExternalModule.php
@@ -87,28 +87,28 @@ class AbstractExternalModule
 		return !preg_match("/[^a-z0-9-_]/", $key);
 	}
 
-	function selectData($some, $params)
+	function selectData($some, $params=array())
 	{
 		self::checkPermissions(__FUNCTION__);
 
 		return 'this could be some data from the database';
 	}
 
-	function updateData($some, $params)
+	function updateData($some, $params=array())
 	{
 		self::checkPermissions(__FUNCTION__);
 
 		throw new Exception('Not yet implemented!');
 	}
 
-	function deleteData($some, $params)
+	function deleteData($some, $params=array())
 	{
 		self::checkPermissions(__FUNCTION__);
 
 		throw new Exception('Not yet implemented!');
 	}
 
-	function updateUserPermissions($some, $params)
+	function updateUserPermissions($some, $params=array())
 	{
 		self::checkPermissions(__FUNCTION__);
 


### PR DESCRIPTION
…: Too few arguments to function" if no $params param was passed to certain methods in AbstractExternalModule.php