### PR TITLE
Remove external modules links in project and control center

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1325,22 +1325,6 @@ class ExternalModules
 			}
 		}
 
-		$addManageLink = function($url) use (&$links){
-			$links['Manage External Modules'] = array(
-				'icon' => 'puzzle_small',
-				'url' => ExternalModules::$BASE_URL  . $url
-			);
-		};
-
-		if(isset($pid)){
-			if(SUPER_USER || !empty($versionsByPrefix) && self::hasDesignRights()){
-				$addManageLink('manager/project.php?');
-			}
-		}
-		else{
-			$addManageLink('manager/control_center.php');
-		}
-
 		ksort($links);
 
 		return $links;


### PR DESCRIPTION
Removing the link to the External Modules manager page from the Control Center menu and project menu since the link has now been integrated natively into REDCap 7.6.1.