### PR TITLE
Ensure compatibility with PHP version and REDCap version before enabling module

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -356,6 +356,9 @@ class ExternalModules
 		# Attempt to create an instance of the module before enabling it system wide.
 		# This should catch problems like syntax errors in module code.
 		$instance = self::getModuleInstance($moduleDirectoryPrefix, $version);
+		
+		// Ensure compatibility with PHP version and REDCap version before instantiating the module class
+		self::isCompatibleWithREDCapPHP($moduleDirectoryPrefix, $version);
 
 		if (!isset($project_id)) {
 			self::initializeSettingDefaults($instance);
@@ -995,8 +998,9 @@ class ExternalModules
 	}
 
 	# Ensure compatibility with PHP version and REDCap version during module installation using config values
-	private static function isCompatibleWithREDCapPHP($config=array())
+	private static function isCompatibleWithREDCapPHP($moduleDirectoryPrefix, $version)
 	{
+		$config = self::getConfig($moduleDirectoryPrefix, $version);
 		if (!isset($config['compatibility'])) return;
 		$Exceptions = array();
 		$compat = $config['compatibility'];
@@ -1028,9 +1032,6 @@ class ExternalModules
 		$instance = @self::$instanceCache[$prefix][$version];
 		if(!isset($instance)){
 			$config = self::getConfig($prefix, $version);
-			
-			// Ensure compatibility with PHP version and REDCap version before instantiating the module class
-			self::isCompatibleWithREDCapPHP($config);
 
 			$namespace = @$config['namespace'];
 			if($namespace) {


### PR DESCRIPTION
Ensure compatibility with PHP version and REDCap version using config values when enabling a module. It will check the JSON attributes seen in the example below. If any attribute is missing or blank, it will be ignored during the check.

"compatibility": {
	"php-version-min": "5.4.0",
	"php-version-max": "",
	"redcap-version-min": "7.0.0",
	"redcap-version-max": ""
}