### PR TITLE
Added REDCap's built-in field validation for text fields in a module's config file

### DIFF
--- a/manager/css/style.css
+++ b/manager/css/style.css
@@ -51,6 +51,14 @@
 	width: 850px;
 }
 
+/* Modify Bootstrap modal z-index because it conflicts with jQuery UI modals */
+.modal-backdrop {
+	z-index: 99;
+}
+.modal {
+	z-index: 100;
+}
+
 #external-modules-configure-modal input[type=radio] {
 	vertical-align: -2px;
 	margin-right: 5px;

--- a/manager/js/globals.js
+++ b/manager/js/globals.js
@@ -208,6 +208,11 @@ ExternalModules.Settings.prototype.getColumnHtml = function(setting,value,classN
 		var inputAttributes = [];
 		if(type == 'checkbox' && value == 1){
 			inputAttributes['checked'] = 'checked';
+		} else if (type == 'text' && typeof setting.validation != "undefined") {
+			var validation = setting.validation;
+			var validation_min = (typeof setting.validation_min == "undefined") ? "" : setting.validation_min;
+			var validation_max = (typeof setting.validation_max == "undefined") ? "" : setting.validation_max;
+			inputAttributes['onblur'] = "redcap_validate(this,'"+validation_min+"','"+validation_max+"','soft_typed','"+validation+"',1);";
 		}
 
 		inputHtml = this.getInputElement(type, key, value, inputAttributes);


### PR DESCRIPTION
Added REDCap's built-in field validation as an option for text input fields set in a module's config file by using attribute "validation" with the additional option of using "validation_min" and/or "validation_max" as optional field-level attributes.