### PR TITLE
add label to indicate global modules

### DIFF
--- a/manager/ajax/get-disabled-modules.php
+++ b/manager/ajax/get-disabled-modules.php
@@ -49,11 +49,20 @@ require_once '../../classes/ExternalModules.php';
 		foreach ($enabledModules as $prefix => $version) {
 			$config = ExternalModules::getConfig($prefix, $version, $_GET['pid']);
 			$enabled = ExternalModules::getProjectSetting($prefix, $_GET['pid'], ExternalModules::KEY_ENABLED);
+			$system_enabled = ExternalModules::getSystemSetting($prefix, ExternalModules::KEY_ENABLED);
 
 			if (!$enabled) {
 			?>
 				<tr data-module='<?= $prefix ?>' data-version='<?= $version ?>'>
-					<td><div class='external-modules-title'><?= $config['name'] ?> <?= $version ?><input type='hidden' name='version' value='<?= $version ?>'></div><div class='external-modules-description'><?php echo $config['description'] ? $config['description'] : '';?></div><div class='external-modules-byline'>
+					<td><div class='external-modules-title'>
+                            <?= $config['name'] ?> <?= $version ?>
+                            <?php if ($system_enabled) print "<span class='label label-warning' title='This module is normally enabled globally for all projects'>Global Module</span>" ?>
+                            <input type='hidden' name='version' value='<?= $version ?>'>
+                        </div>
+                        <div class='external-modules-description'>
+                            <?php echo $config['description'] ? $config['description'] : '';?>
+                        </div>
+                        <div class='external-modules-byline'>
 <?php
 	if ($config['authors']) {
 		$names = array();

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -176,13 +176,17 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 
 			$configsByPrefix[$prefix] = $config;
 			$enabled = false;
+			$system_enabled = ExternalModules::getSystemSetting($prefix, ExternalModules::KEY_ENABLED);
+
 			if (isset($_GET['pid'])) {
 				$enabled = ExternalModules::getProjectSetting($prefix, $_GET['pid'], ExternalModules::KEY_ENABLED);
 			}
 			if ((isset($_GET['pid']) && $enabled) || (!isset($_GET['pid']) && isset($config['system-settings']))) {
 			?>
 				<tr data-module='<?= $prefix ?>' data-version='<?= $version ?>'>
-					<td><div class='external-modules-title'><?= $config['name'] . ' - ' . $version ?></div><div class='external-modules-description'><?php echo $config['description'] ? $config['description'] : ''; ?></div><div class='external-modules-byline'>
+					<td><div class='external-modules-title'><?= $config['name'] . ' - ' . $version ?>
+                            <?php if ($system_enabled) print "<span class='label label-warning'>Enabled for All Projects</span>" ?>
+                        </div><div class='external-modules-description'><?php echo $config['description'] ? $config['description'] : ''; ?></div><div class='external-modules-byline'>
 <?php
         if ($config['authors']) {
                 $names = array();


### PR DESCRIPTION
It is useful to know if a module is 'global' or 'per project optional'
at a glance