### PR TITLE
Adds "delete module" functionality in the UI

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1815,23 +1815,6 @@ class ExternalModules
 		return self::isTesting() || SUPER_USER;
 	}
 
-	# Taken from: http://stackoverflow.com/questions/3338123/how-do-i-recursively-delete-a-directory-and-its-entire-contents-files-sub-dir
-	private static function rrmdir($dir)
-	{
-		if (is_dir($dir)) {
-			$objects = scandir($dir);
-			foreach ($objects as $object) {
-				if ($object != "." && $object != "..") {
-					if (is_dir($dir . "/" . $object))
-						self::rrmdir($dir . "/" . $object);
-					else
-						unlink($dir . "/" . $object);
-				}
-			}
-			rmdir($dir);
-		}
-	}
-
 	# there is no getInstance because settings returns an array of repeated elements
 	# getInstance would merely consist of dereferencing the array; Ockham's razor
 
@@ -2019,7 +2002,7 @@ class ExternalModules
 		   exit("1");
 		}
 		// Delete the directory
-		if (!self::deleteDirectory($moduleFolderDir)) exit("0");
+		if (!self::rrmdir($moduleFolderDir)) exit("0");
 		// Remove row from redcap_external_modules_downloads table
 		$sql = "delete from redcap_external_modules_downloads where module_name = '".db_escape($moduleFolderName)."'";
 		db_query($sql);
@@ -2030,7 +2013,7 @@ class ExternalModules
 	}
 	
 	# general method to delete a directory by first deleting all files inside it
-	public static function deleteDirectory($dirPath) 
+	public static function rrmdir($dirPath) 
 	{
 		if (!is_dir($dirPath)) return false;
 		if (substr($dirPath, strlen($dirPath) - 1, 1) != DS) {
@@ -2040,7 +2023,7 @@ class ExternalModules
 		$files = glob($dirPath . '*', GLOB_MARK);
 		foreach ($files as $file) {
 			if (is_dir($file)) {
-				self::deleteDirectory($file);
+				self::rrmdir($file);
 			} else {
 				unlink($file);
 			}

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1997,6 +1997,11 @@ class ExternalModules
 		if (!(file_exists($moduleFolderDir) && is_dir($moduleFolderDir))) {
 		   exit("3");
 		}
+		// Add row to redcap_external_modules_downloads table
+		$sql = "insert into redcap_external_modules_downloads (module_name, time_downloaded) 
+				values ('".db_escape($moduleFolderName)."', '".NOW."')
+				on duplicate key update time_downloaded = '".NOW."'";
+		db_query($sql);
 		// Log this event
 		\REDCap::logEvent("Download external module \"$moduleFolderName\" from repository");
 		// Give success message
@@ -2015,6 +2020,9 @@ class ExternalModules
 		}
 		// Delete the directory
 		if (!self::deleteDirectory($moduleFolderDir)) exit("0");
+		// Remove row from redcap_external_modules_downloads table
+		$sql = "delete from redcap_external_modules_downloads where module_name = '".db_escape($moduleFolderName)."'";
+		db_query($sql);
 		// Log this event
 		\REDCap::logEvent("Delete external module \"$moduleFolderName\" from system");
 		// Give success message

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1997,6 +1997,8 @@ class ExternalModules
 		if (!(file_exists($moduleFolderDir) && is_dir($moduleFolderDir))) {
 		   exit("3");
 		}
+		// Log this event
+		\REDCap::logEvent("Download external module \"$moduleFolderName\" from repository");
 		// Give success message
 		print "The module was successfully downloaded to the REDCap server, and can now be enabled.";
 	}
@@ -2013,6 +2015,8 @@ class ExternalModules
 		}
 		// Delete the directory
 		if (!self::deleteDirectory($moduleFolderDir)) exit("0");
+		// Log this event
+		\REDCap::logEvent("Delete external module \"$moduleFolderName\" from system");
 		// Give success message
 		print "The module and its corresponding directory were successfully deleted from the REDCap server.";
 	}

--- a/manager/ajax/delete-module.php
+++ b/manager/ajax/delete-module.php
@@ -1,4 +1,4 @@
 <?php
 namespace ExternalModules;
 require_once '../../classes/ExternalModules.php';
-ExternalModules::deleteModuleDirectory($_POST['module_dir']);
+print ExternalModules::deleteModuleDirectory($_POST['module_dir']);

--- a/manager/ajax/delete-module.php
+++ b/manager/ajax/delete-module.php
@@ -1,4 +1,4 @@
 <?php
 namespace ExternalModules;
 require_once '../../classes/ExternalModules.php';
-ExternalModules::downloadModule($_GET['module_id']);
+ExternalModules::deleteModuleDirectory($_POST['module_dir']);

--- a/manager/ajax/download-module.php
+++ b/manager/ajax/download-module.php
@@ -1,4 +1,4 @@
 <?php
 namespace ExternalModules;
 require_once '../../classes/ExternalModules.php';
-ExternalModules::downloadModule($_GET['module_id']);
+print ExternalModules::downloadModule($_GET['module_id']);

--- a/manager/ajax/get-disabled-modules.php
+++ b/manager/ajax/get-disabled-modules.php
@@ -18,12 +18,19 @@ require_once '../../classes/ExternalModules.php';
 		} else {
 			foreach ($disabledModuleConfigs as $moduleDirectoryPrefix => $versions) {
 				$config = reset($versions);
+				
+				// Determine if module is an example module
+				$isExampleModule = ExternalModules::isExampleModule($moduleDirectoryPrefix, array_keys($versions));
 	
 				if(isset($enabledModules[$moduleDirectoryPrefix])){
 					$enableButtonText = 'Change Version';
+					$enableButtonIcon = 'glyphicon-refresh';
+					$deleteButtonDisabled = 'disabled'; // Modules cannot be deleted if they are currently enabled
 				}
 				else{
 					$enableButtonText = 'Enable';
+					$enableButtonIcon = 'glyphicon-plus-sign';
+					$deleteButtonDisabled = $isExampleModule ? 'disabled' : ''; // Modules cannot be deleted if they are example modules
 				}
 	
 				?>
@@ -39,7 +46,8 @@ require_once '../../classes/ExternalModules.php';
 						</select>
 					</td>
 					<td class="external-modules-action-buttons">
-						<button class='enable-button'><?=$enableButtonText?></button>
+						<button class='btn btn-success btn-xs enable-button'><span class="glyphicon <?=$enableButtonIcon?>" aria-hidden="true"></span> <?=$enableButtonText?></button> &nbsp;
+						<button class='btn btn-default btn-xs disable-button' <?=$deleteButtonDisabled?>><span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete module</button>
 					</td>
 				</tr>
 				<?php

--- a/manager/js/get-disabled-modules.js
+++ b/manager/js/get-disabled-modules.js
@@ -5,13 +5,36 @@ $(function(){
 
 	var reloadThisPage = function(){
 		$('<div class="modal-backdrop fade in"></div>').appendTo(document.body);
-		var loc = window.location;
-		window.location = loc.protocol + '//' + loc.host + loc.pathname + loc.search;
+		window.location.reload();
 	}
+
+	disabledModal.find('.disable-button').click(function(event){
+		var row = $(event.target).closest('tr');
+		var title = row.find('td:eq(0)').text().trim();
+		var prefix = row.data('module');
+		var version = row.find('[name="version"]').val();		
+		simpleDialog("Do you wish to delete the module \"<b>"+title+"</b>\" (<b>"+prefix+"_"+version+"</b>)? "
+			+"Doing so will permanently remove the module's directory from the REDCap server.","DELETE MODULE?",null,null,null,"Cancel",function(){
+				showProgress(1);
+				$.post('ajax/delete-module.php', { module_dir: prefix+'_'+version },function(data){
+					showProgress(0,0);
+					if (data == '1') {
+						simpleDialog("An error occurred because the External Module directory could not be found on the REDCap web server.","ERROR");
+					} else if (data == '0') {
+						simpleDialog("An error occurred because the External Module directory could not be deleted from the REDCap web server.","ERROR");
+					} else {
+						$('#external-modules-disabled-modal').hide();
+						simpleDialog(data,"SUCCESS",null,null,function(){
+							window.location.reload();
+						},"Close");
+					}
+				});
+			},"Delete module");
+		return false;
+	});
 
 	disabledModal.find('.enable-button').click(function(event){
 		disabledModal.hide();
-		$('#external-modules-enable-modal-error').hide();
 
 		var row = $(event.target).closest('tr');
 		var prefix = row.data('module');

--- a/manager/js/project.js
+++ b/manager/js/project.js
@@ -2,8 +2,7 @@ $(function() {
 
 	 var reloadPage = function(){
 		  $('<div class="modal-backdrop fade in"></div>').appendTo(document.body);
-		  var loc = window.location;
-		  window.location = loc.protocol + '//' + loc.host + loc.pathname + loc.search;
+		 window.location.reload();
 	 }
 
 	$('.external-modules-disable-button').click(function (event) {	

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -115,9 +115,9 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 <br>
 <?php if(SUPER_USER) { ?>
 	<button id="external-modules-enable-modules-button" class="btn btn-success btn-sm">
-		<span class="glyphicon glyphicon-off" aria-hidden="true"></span>
+		<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
 		Enable a module
-	</button>
+	</button> &nbsp; 
 <?php } ?>
 <?php if (SUPER_USER && !isset($_GET['pid'])) { ?>
 	<button id="external-modules-download-modules-button" class="btn btn-primary btn-sm">


### PR DESCRIPTION
Adds a "delete module" button in the Available Modules dialog in the Control Center. When clicked (after a confirmation), it will remove the module directory from the REDCap server. Note: Example modules (those included in the Ext Mod package) are not allowed to be deleted, nor are modules that are enabled. A module must be disabled before it can be deleted.

Screenshot:
![delete-module](https://user-images.githubusercontent.com/412979/30873768-ec66336c-a2b3-11e7-92d8-ffc5704b0240.png)
