### PR TITLE
Fix isLocalhost() dependency on IP assumption

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -109,11 +109,10 @@ class ExternalModules
 	private static function isLocalhost()
 	{
 		$host = @$_SERVER['HTTP_HOST'];
+		
+		$is_dev_server = (isset($GLOBALS['is_development_server']) && $GLOBALS['is_development_server'] == '1');
 
-		// If the hostname is an IP address, assume we're accessing a developer's PC and return true.
-		$isIpAddress = ip2long($host);
-
-		return $host == 'localhost' || $isIpAddress;
+		return $host == 'localhost' || $is_dev_server;
 	}
 
 	static function saveSettings($moduleDirectoryPrefix, $pid, $settings)


### PR DESCRIPTION
Added usage of $is_development_server global setting in isLocalhost() to prevent the assumption that servers with an IP web address are always a dev/test/staging server. Note: $is_development_server exists only in REDCa 7.6.7 and later.