### PR TITLE
Add "discoverable" attribute for modules

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -41,6 +41,7 @@ class ExternalModules
 	const SYSTEM_SETTING_PROJECT_ID = 'NULL';
 	const KEY_VERSION = 'version';
 	const KEY_ENABLED = 'enabled';
+	const KEY_DISCOVERABLE = 'discoverable-in-project';
 
 	const TEST_MODULE_PREFIX = 'UNIT-TESTING-PREFIX';
 
@@ -102,6 +103,11 @@ class ExternalModules
 			'project-name' => 'Enable on this project',
 			'type' => 'checkbox',
 			'allow-project-overrides' => true,
+		),
+		array(
+			'key' => self::KEY_DISCOVERABLE,
+			'name' => 'Make module discoverable - Display info to users on External Modules page in all projects',
+			'type' => 'checkbox'
 		)
 	);
 
@@ -1983,5 +1989,26 @@ class ExternalModules
 		}
 		// Give success message
 		print "The module was successfully downloaded to the REDCap server, and can now be enabled.";
+	}
+	
+	// Return array of module dir prefixes for modules with a system-level value of TRUE for discoverable-in-project
+	public static function getDiscoverableModules()
+	{
+		$modules = array();
+		$sql = "select m.directory_prefix from redcap_external_module_settings s, redcap_external_modules m
+				where m.external_module_id = s.external_module_id and s.project_id is null
+				and `value` = 'true' and `key` = '".db_escape(self::KEY_DISCOVERABLE)."'";
+		$q = db_query($sql);
+		while ($row = db_fetch_assoc($q)) {
+			$modules[] = $row['directory_prefix'];
+		}
+		return $modules;
+	}
+	
+	// Return boolean if any projects have a system-level value of TRUE for discoverable-in-project
+	public static function hasDiscoverableModules()
+	{
+		$modules = self::getDiscoverableModules();
+		return !empty($modules);
 	}
 }

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -106,7 +106,7 @@ class ExternalModules
 		),
 		array(
 			'key' => self::KEY_DISCOVERABLE,
-			'name' => 'Make module discoverable - Display info to users on External Modules page in all projects',
+			'name' => 'Make module discoverable by users - Display info on External Modules page in all projects',
 			'type' => 'checkbox'
 		)
 	);

--- a/manager/ajax/disable-module.php
+++ b/manager/ajax/disable-module.php
@@ -3,6 +3,9 @@ namespace ExternalModules;
 
 require_once '../../classes/ExternalModules.php';
 
+// Only administrators can enable/disable modules
+if (!SUPER_USER) exit;
+
 $module = $_POST['module'];
 
 if (empty($module)) {

--- a/manager/ajax/enable-module.php
+++ b/manager/ajax/enable-module.php
@@ -3,6 +3,9 @@ namespace ExternalModules;
 
 require_once '../../classes/ExternalModules.php';
 
+// Only administrators can enable/disable modules
+if (!SUPER_USER) exit;
+
 $return_data['message'] = "success";
 
 if (isset($_GET['pid'])) {

--- a/manager/ajax/get-disabled-modules.php
+++ b/manager/ajax/get-disabled-modules.php
@@ -68,28 +68,30 @@ require_once '../../classes/ExternalModules.php';
                             <?php echo $config['description'] ? $config['description'] : '';?>
                         </div>
                         <div class='external-modules-byline'>
-<?php
-	if ($config['authors']) {
-		$names = array();
-		foreach ($config['authors'] as $author) {
-			$name = $author['name'];
-            $institution = empty($author['institution']) ? "" : " <span class='author-institution'>({$author['institution']})</span>";
-			if ($name) {
-				if ($author['email']) {
-					$names[] = "<a href='mailto:".$author['email']."'>".$name."</a> $institution";
-				} else {
-					$names[] = $name .  $institution;
-				}
-			}
-		}
-		if (count($names) > 0) {
-			echo "by ".implode($names, ", ");
-		}
-	}
-?>
-</div></td>
-					<td style='vertical-align: middle;' class="external-modules-action-buttons">
+					<?php
+						if ($config['authors']) {
+							$names = array();
+							foreach ($config['authors'] as $author) {
+								$name = $author['name'];
+								$institution = empty($author['institution']) ? "" : " <span class='author-institution'>({$author['institution']})</span>";
+								if ($name) {
+									if ($author['email']) {
+										$names[] = "<a href='mailto:".$author['email']."'>".$name."</a> $institution";
+									} else {
+										$names[] = $name .  $institution;
+									}
+								}
+							}
+							if (count($names) > 0) {
+								echo "by ".implode($names, ", ");
+							}
+						}
+					?>
+					</div></td>
+					<td class="external-modules-action-buttons">
+						<?php if (SUPER_USER) { ?>
 						<button class='enable-button'>Enable</button>
+						<?php } ?>
 					</td>
 				</tr>
 			<?php

--- a/manager/ajax/usage.php
+++ b/manager/ajax/usage.php
@@ -2,9 +2,12 @@
 namespace ExternalModules;
 require_once '../../classes/ExternalModules.php';
 
+// Only administrators can perform this action
+if (!SUPER_USER) exit;
+
 $projects = ExternalModules::getEnabledProjects($_GET['prefix']);
 
 while($project = db_fetch_assoc($projects)){
 	$url = APP_PATH_WEBROOT . 'ProjectSetup/index.php?pid=' . $project['project_id'];
-	?><a href="<?=$url?>" style="text-decoration: underline;"><?=$project['name']?></a><br><?php
+	?><a href="<?=$url?>" style="text-decoration: underline;"><?=\RCView::escape(strip_tags($project['name']))?></a><br><?php
 }

--- a/manager/project.php
+++ b/manager/project.php
@@ -3,7 +3,7 @@ namespace ExternalModules;
 require_once __DIR__ . '/../classes/ExternalModules.php';
 require_once ExternalModules::getProjectHeaderPath();
 
-if(!ExternalModules::hasDesignRights()){
+if(!ExternalModules::hasDesignRights() && !ExternalModules::hasDiscoverableModules()){
 	echo "You don't have permission to manage external modules on this project.";
 	return;
 }

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -90,6 +90,18 @@ may also need to set on the project page.</p>
 
 <?php } ?>
 
+<?php if (isset($_GET['pid'])) { ?>
+
+<p style="color:#800000;font-size:11px;line-height:13px;">
+	<b>DISCLAIMER:</b> Please be aware that External Modules are not part of the REDCap software but instead are add-on packages
+	that, in most cases, have been created by software developers at other REDCap institutions.
+	Be aware that the entire risk as to the quality and performance of the module as it is used in your REDCap project 
+	is borne by you and your local REDCap administator. 
+	If you experience any issues with a module, your REDCap administrator should contact the author of that particular module.
+</p>
+
+<?php } ?>
+
 <?php
 // Ensure that server is running PHP 5.4.0+ since REDCap's minimum requirement is PHP 5.3.0
 if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -104,7 +104,7 @@ may also need to set on the project page.</p>
 
 // Show custom external modules text (optional)
 if (isset($GLOBALS['external_modules_project_custom_text']) && trim($GLOBALS['external_modules_project_custom_text']) != "") {
-	print \RCView::div(array('style'=>'max-width:800px;border:1px solid #ccc;background-color:#f5f5f5;margin:15px 0;padding:8px;'), nl2br(decode_filter_tags($GLOBALS['external_modules_project_custom_text'])));
+	print \RCView::div(array('id'=>'external_modules_project_custom_text', 'style'=>'max-width:800px;border:1px solid #ccc;background-color:#f5f5f5;margin:15px 0;padding:8px;'), nl2br(decode_filter_tags($GLOBALS['external_modules_project_custom_text'])));
 }
 
 }

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -6,13 +6,6 @@ use Exception;
 
 ExternalModules::addResource('css/style.css');
 
-$sql = ExternalModules::getSqlToRunIfDBOutdated();
-if($sql !== ""){
-	echo '<p>Your current database table structure does not match REDCap\'s expected table structure for External Modules, which means that database tables and/or parts of tables are missing. Copy the SQL in the box below and execute it in the MySQL database named '.$db.' where the REDCap database tables are stored. Once the SQL has been executed, reload this page to run this check again.</p>';
-	echo '<textarea style="width: 100%; height: 300px" onclick="this.focus();this.select()" readonly="readonly">' . $sql . '</textarea>';
-	return;
-}
-
 $pid = $_GET['pid'];
 $disableModuleConfirmProject = (isset($_GET['pid']) & !empty($_GET['pid'])) ? " for the current project" : "";
 ?>
@@ -111,12 +104,18 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 	require_once APP_PATH_DOCROOT . 'ControlCenter/footer.php';
 	exit;
 }
+
+$displayModuleDialogBtn = (SUPER_USER || ExternalModules::hasDiscoverableModules());
+$moduleDialogBtnText = SUPER_USER ? "Enable a module" : "View available modules";
+$moduleDialogBtnImg = SUPER_USER ? "glyphicon-plus-sign" : "glyphicon-info-sign";
+$discoverableModules = ExternalModules::getDiscoverableModules();
+
 ?>
 <br>
-<?php if(SUPER_USER) { ?>
+<?php if($displayModuleDialogBtn) { ?>
 	<button id="external-modules-enable-modules-button" class="btn btn-success btn-sm">
-		<span class="glyphicon glyphicon-off" aria-hidden="true"></span>
-		Enable a module
+		<span class="glyphicon <?=$moduleDialogBtnImg?>" aria-hidden="true"></span>
+		<?=$moduleDialogBtnText?>
 	</button>
 <?php } ?>
 <?php if (SUPER_USER && !isset($_GET['pid'])) { ?>

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -100,9 +100,15 @@ may also need to set on the project page.</p>
 	If you experience any issues with a module, your REDCap administrator should contact the author of that particular module.
 </p>
 
-<?php } ?>
-
 <?php
+
+// Show custom external modules text (optional)
+if (isset($GLOBALS['external_modules_project_custom_text']) && trim($GLOBALS['external_modules_project_custom_text']) != "") {
+	print \RCView::div(array('style'=>'max-width:800px;border:1px solid #ccc;background-color:#f5f5f5;margin:15px 0;padding:8px;'), nl2br(decode_filter_tags($GLOBALS['external_modules_project_custom_text'])));
+}
+
+}
+
 // Ensure that server is running PHP 5.4.0+ since REDCap's minimum requirement is PHP 5.3.0
 if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 	?>


### PR DESCRIPTION
Allows individual modules to be set as "discoverable" (i.e., advertised to users as being available for use). This is done in a module's system-level configuration so that users can discover them in the project UI, in which it exposes the project-level module manager page if at least one module is discoverable  (regardless of user permissions) in the whole system. And when viewing the module manager page in the project, the user can click the "View available modules" button to see _only_ the ones that have been set as discoverable (in addition to ones already enabled in that project). The user cannot do anything with the modules that are discoverable, but they can merely view the modules and their descriptions to learn about them. 