### PR TITLE
Add user permission to modify project config

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -41,6 +41,7 @@ class ExternalModules
 	const SYSTEM_SETTING_PROJECT_ID = 'NULL';
 	const KEY_VERSION = 'version';
 	const KEY_ENABLED = 'enabled';
+	const KEY_CONFIG_USER_PERMISSION = 'config-require-user-permission';
 
 	const TEST_MODULE_PREFIX = 'UNIT-TESTING-PREFIX';
 
@@ -98,10 +99,21 @@ class ExternalModules
 		),
 		array(
 			'key' => self::KEY_ENABLED,
-			'name' => 'Enable on all projects by default',
+			'name' => '<b>Enable module on all projects by default:</b><br>Unchecked (default) = Module must be enabled in each project individually',
 			'project-name' => 'Enable on this project',
 			'type' => 'checkbox',
 			'allow-project-overrides' => true,
+		),
+		array(
+			'key' => self::KEY_CONFIG_USER_PERMISSION,
+			'name' => '<b>Module configuration permissions in projects:</b><br>By default, users with Project Setup/Design privileges can '
+					. 'modify this module\'s project-level configuration settings. Alternatively, project users can be given explicit '
+					. 'module-level permission (via User Rights page) in order to do so',
+			'type' => 'dropdown',
+			"choices" => array(
+				array("value" => "", "name" => "Require Project Setup/Design privilege"),
+				array("value" => "true", "name" => "Require module-specific user privilege")
+			)
 		)
 	);
 
@@ -1694,6 +1706,12 @@ class ExternalModules
 			if(isset($existingSettingKeys[$key])){
 				throw new Exception("The '$key' setting key is reserved for internal use.  Please use a different setting key in your module.");
 			}
+			
+			// If project has no project-level configuration, then do not add the reserved setting 
+			// to require special user right in project to modify project config
+			if ($key == self::KEY_CONFIG_USER_PERMISSION && empty($projectSettings)) {
+				continue;
+			}
 
 			if(@$details['hidden'] != true){
 				$visibleReservedSettings[] = $details;
@@ -1732,8 +1750,12 @@ class ExternalModules
 		if(self::hasSystemSettingsSavePermission($moduleDirectoryPrefix)){
 			return true;
 		}
+		
+		$moduleRequiresConfigUserRights = self::moduleRequiresConfigPermission($moduleDirectoryPrefix);
+		$userCanConfigureModule = ((!$moduleRequiresConfigUserRights && self::hasDesignRights()) 
+									|| ($moduleRequiresConfigUserRights && self::hasModuleConfigurationUserRights($moduleDirectoryPrefix)));
 
-		if(self::hasDesignRights()){
+		if($userCanConfigureModule){
 			if(!self::isSystemSetting($moduleDirectoryPrefix, $key)){
 				return true;
 			}
@@ -1794,6 +1816,23 @@ class ExternalModules
 
 		$rights = \REDCap::getUserRights();
 		return $rights[USERID]['design'] == 1;
+	}
+
+	# returns boolean if current user explicitly has project-level user rights to configure a module 
+	# (assuming it requires explicit privileges based on system-level configuration of module)
+	static function hasModuleConfigurationUserRights($prefix=null)
+	{
+		if(SUPER_USER){
+			return true;
+		}
+
+		if(!isset($_GET['pid'])){
+			// REDCap::getUserRights() will crash if no pid is set, so just return false.
+			return false;
+		}
+
+		$rights = \REDCap::getUserRights();
+		return in_array($prefix, $rights[USERID]['external_module_config']);
 	}
 
 	static function hasSystemSettingsSavePermission()
@@ -1984,4 +2023,57 @@ class ExternalModules
 		// Give success message
 		print "The module was successfully downloaded to the REDCap server, and can now be enabled.";
 	}
+	
+	# Return array all all module prefixes where the module requires that regular users have project-level 
+	# permissions in order to configure it for the project. First provide an array of dir prefixes that you want to check.
+	public static function getModulesRequireConfigPermission($prefixes=array())
+	{
+		$modules = array();
+		if (empty($prefixes)) return $modules;
+		$sql = "SELECT m.directory_prefix FROM redcap_external_modules m, redcap_external_module_settings s 
+				WHERE m.external_module_id = s.external_module_id AND s.value = 'true'
+				AND s.`key` = '" . self::KEY_CONFIG_USER_PERMISSION . "' AND m.directory_prefix in (" . prep_implode($prefixes) . ")";
+		$q = self::query($sql);
+		while ($row = db_fetch_assoc($q)) {
+			$modules[] = $row['directory_prefix'];
+		}
+		return $modules;
+	}
+	
+	# Return boolean if module requires that regular users have project-level 
+	# permissions in order to configure it for the project.
+	public static function moduleRequiresConfigPermission($prefix=null)
+	{
+		$module = self::getModulesRequireConfigPermission(array($prefix));
+		return !empty($module);
+	}
+	
+	# Return array all all modules enabled in a project where the module requires that regular users have project-level 
+	# permissions in order to configure it for the project. Array also contains module title.
+	public static function getModulesWithCustomUserRights($project_id=null)
+	{
+		// Place modules into an array
+		$modulesAttributes = $titles = array();
+		// Get modules enabled for this project
+		$enabledModules = self::getEnabledModules($project_id);
+		// Of the enabled projects, find those that require user permissions to configure in project
+		$enabledModulesReqConfigPerm = self::getModulesRequireConfigPermission(array_keys($enabledModules));
+		// Obtain the title of each module from its config
+		foreach (array_keys($enabledModules) as $thisModule) {		
+			$config = self::getConfig($thisModule, null, $project_id);
+			if (!isset($config['name'])) continue;
+			// Add attributes to array
+			$title = trim(strip_tags($config['name']));
+			$modulesAttributes[$thisModule] = array('name'=>$title, 
+													'has-project-config'=>((isset($config['project-settings']) && !empty($config['project-settings'])) ? 1 : 0), 
+													'require-config-perm'=>(in_array($thisModule, $enabledModulesReqConfigPerm) ? 1 : 0));
+			// Add title to another array so we can sort by title
+			$titles[] = $title;
+		}
+		// Sort modules by title
+		array_multisort($titles, SORT_REGULAR, $modulesAttributes);
+		// Return modules with attributes
+		return $modulesAttributes;
+	}
+	
 }

--- a/manager/js/globals.js
+++ b/manager/js/globals.js
@@ -246,10 +246,11 @@ ExternalModules.Settings.prototype.getSelectElement = function(name, choices, se
 	}
 
 	var optionsHtml = '';
-	optionsHtml += '<option value=""></option>';
+	var choiceHasBlankValue = false;
 	for(var i in choices ){
 		var choice = choices[i];
-		var value = choice.value;
+		var value = choice.value;		
+		if (value == '') choiceHasBlankValue = true;
 
 		var optionAttributes = ''
 		if(value == selectedValue){
@@ -257,6 +258,10 @@ ExternalModules.Settings.prototype.getSelectElement = function(name, choices, se
 		}
 
 		optionsHtml += '<option value="' + this.getAttributeValueHtml(value) + '" ' + optionAttributes + '>' + choice.name + '</option>';
+	}
+	
+	if (!choiceHasBlankValue) {
+		optionsHtml = '<option value=""></option>' + optionsHtml;
 	}
 
 	var defaultAttributes = {"class" : "external-modules-input-element"};

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -209,7 +209,8 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 ?>
 </div></td>
 					<td class="external-modules-action-buttons">
-						<?php if(ExternalModules::isProjectSettingsConfigOverwrittenBySystem($config) || !empty($config['project-settings']) || (!empty($config['system-settings']) && !isset($_GET['pid']))){?>
+						<?php if((ExternalModules::isProjectSettingsConfigOverwrittenBySystem($config) || !empty($config['project-settings']) || (!empty($config['system-settings']) && !isset($_GET['pid'])))
+							&& (!isset($_GET['pid']) || (isset($_GET['pid']) && self::hasProjectSettingSavePermission($prefix)))){?>
 							<button class='external-modules-configure-button'>Configure</button>
 						<?php } ?>
 						<?php if(SUPER_USER) { ?>


### PR DESCRIPTION
Adding more granular controls for who can modify a module's project-level configuration settings. When enabling a module in the Control Center, REDCap admins can set a module to require module-specific permission (via a project's User Rights page) in order to allow them to modify its configuration in a project, else it reverts to the default, which is that it requires Project Setup/Design privileges to configure the module.
![perm2](https://user-images.githubusercontent.com/412979/31097597-70f1fcda-a785-11e7-993c-76bcf99ed53e.png)

On User Rights page:
![perm1](https://user-images.githubusercontent.com/412979/31097559-4fb3b1a8-a785-11e7-9011-64a9fc2c55f4.png)
