### PR TITLE
Add custom text to Project Module Manager page

### DIFF
--- a/manager/control_center.php
+++ b/manager/control_center.php
@@ -5,10 +5,29 @@ require_once APP_PATH_DOCROOT . 'ControlCenter/header.php';
 
 ?>
 
-<h4 style="margin-top: 0;">
-	<img src='../images/puzzle_medium.png'>
-	External Modules - Module Manager
+<h4 style="margin-top:0;" class="clearfix">
+	<div class="pull-left">
+		<img src='../images/puzzle_medium.png'>
+		External Modules - Module Manager
+	</div>	
+	<div class="pull-right" style="margin-top:5px;">
+		<button id="external-modules-add-custom-text-button" class="btn btn-defaultrc btn-xs">
+			<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+			Set custom text for Project Module Manager page
+		</button>
+	</div>
 </h4>
+
+<div id="external-modules-custom-text-dialog" class="simpleDialog" role="dialog">
+	You may optionally provide custom text in the text box below that will appear to users on the External Modules "Project Module Manager" page in each project.
+	It may be useful to provide some custom text to users for any of the following reasons: 
+	1) To make users aware of institutional policies or procedures required before an administrator can enable a module, 
+	2) To display guidelines (or a link to an external page with guidelines) regarding the usage of particular modules at your institution, 
+	or 3) To bring to the user's attention anything that might be helpful regarding particular modules or External Modules in general.
+	<br><br><b>Custom text displayed on Project Module Manager page:</b><br>
+	<textarea id="external_modules_project_custom_text" class="x-form-field notesbox"><?=htmlspecialchars($external_modules_project_custom_text, ENT_QUOTES)?></textarea>
+	<div class="cc_info">NOTE: HTML may be used in order to adjust the style of the text or to display links, images, etc.</div>
+</div>
 
 <?php
 ExternalModules::safeRequireOnce('templates/enabled-modules.php');

--- a/manager/templates/globals.php
+++ b/manager/templates/globals.php
@@ -60,6 +60,27 @@ ExternalModules::addResource(ExternalModules::getManagerJSDirectory().'globals.j
         $('#external-modules-download-modules-button').click(function(){
 			window.location.href = ExternalModules.LIB_URL;
 		});
+        $('#external-modules-add-custom-text-button').click(function(){
+			$('#external-modules-custom-text-dialog').dialog({ title: 'Set custom text for Project Module Manager (optional)', bgiframe: true, modal: true, width: 550, 
+				buttons: {
+					'Cancel': function() {
+						$(this).dialog('close'); 
+					},
+					'Save': function() {
+						showProgress(1,0);
+						$.post(app_path_webroot+'ControlCenter/set_config_val.php',{ settingName: 'external_modules_project_custom_text', value: $('#external_modules_project_custom_text').val() },function(data){
+							showProgress(0,0);
+							if (data == '1') {
+								simpleDialog("The custom text was successfully saved!","SUCCESS");
+							} else {
+								alert(woops);
+							}
+						});
+						$(this).dialog('close'); 
+					}
+				} 
+			});
+		});
 		if (isNumeric(getParameterByName('download_module_id')) && getParameterByName('download_module_name') != '') {
 			$('#external-modules-download').dialog({ title: 'Download external module?', bgiframe: true, modal: true, width: 550, 
 				close: function() { 


### PR DESCRIPTION
Added a button at the top of the Control Center module manager page to allow REDCap admins to optionally add custom text that gets displayed on the Project Module Manager page in each project (as a means to provide custom institutional-specific language regarding modules). Note: This sets a REDCap config setting that was added in REDCap 7.6.7. Also, this branch does not contain the code to display this custom text on the Project Module Manager page but only to *save* the text. This is because the code to display the text was added in an earlier pull request (https://github.com/vanderbilt/redcap-external-modules/pull/35/), so my apologies for any confusion.