### PR TITLE
Remove author listing from Project Module Manager page

### DIFF
--- a/manager/ajax/get-disabled-modules.php
+++ b/manager/ajax/get-disabled-modules.php
@@ -69,6 +69,7 @@ require_once '../../classes/ExternalModules.php';
                         </div>
                         <div class='external-modules-byline'>
 <?php
+if (SUPER_USER && !isset($_GET['pid'])) {
 	if ($config['authors']) {
 		$names = array();
 		foreach ($config['authors'] as $author) {
@@ -86,10 +87,11 @@ require_once '../../classes/ExternalModules.php';
 			echo "by ".implode($names, ", ");
 		}
 	}
+}
 ?>
 </div></td>
 					<td style='vertical-align: middle;' class="external-modules-action-buttons">
-						<button class='enable-button'>Enable</button>
+						<?php if (SUPER_USER) { ?><button class='enable-button'>Enable</button><?php } ?>
 					</td>
 				</tr>
 			<?php

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -189,6 +189,7 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
                             <?php if ($system_enabled) print "<span class='label label-warning'>Enabled for All Projects</span>" ?>
                         </div><div class='external-modules-description'><?php echo $config['description'] ? $config['description'] : ''; ?></div><div class='external-modules-byline'>
 <?php
+	if (SUPER_USER && !isset($_GET['pid'])) {
         if ($config['authors']) {
                 $names = array();
                 foreach ($config['authors'] as $author) {
@@ -206,6 +207,7 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
                         echo "by ".implode($names, ", ");
                 }
         }
+}
 ?>
 </div></td>
 					<td class="external-modules-action-buttons">


### PR DESCRIPTION
Removes the author's name, email, and institution from the Project Module Manager (but still displays them on the Control Center Module Manager). @mmcev106 and I talked about this, and we both agreed that it would not be the best idea to list the author's name/email to end-users on that page. I would fear that end-users might suddenly start contacting the author, when it would instead be more appropriate for the REDCap administrator to contact the author (if they ever needed to). Plus i'm sure some authors might not want their name and email advertised to tens of thousands of REDCap users all around the world. This way, the admin remains the point person for the module and its author since the author info is still displayed on the Control Center Module Manager.