### PR TITLE
sql command is no longer required

### DIFF
--- a/sql/migration-2017-01-18_10-03-00.sql
+++ b/sql/migration-2017-01-18_10-03-00.sql
@@ -1,4 +1,2 @@
-ALTER TABLE `redcap_external_module_settings` ADD COLUMN `type` VARCHAR(12) NOT NULL DEFAULT 'string' AFTER `key`;
-
 UPDATE `redcap_external_module_settings` SET `type` = 'boolean', `value` = 'true' WHERE `key` = 'enabled' AND value = 1;
 UPDATE `redcap_external_module_settings` SET `type` = 'boolean', `value` = 'false' WHERE `key` = 'enabled' AND value = 0;


### PR DESCRIPTION
the "create tables.sql" file already contains the type column. I was following the direction on installing the external modules on this repo. After removing the first line "ALTER TABLE `redcap_external_module_settings` ADD COLUMN `type` VARCHAR(12) NOT NULL DEFAULT 'string' AFTER `key`;" on the migration-2017-01-18_10-03-00.sql , I was able to continue.