### PR TITLE
Adding new "descriptive" configuration field type

### DIFF
--- a/docs/official-documentation.md
+++ b/docs/official-documentation.md
@@ -88,9 +88,11 @@ Below is a *mostly* comprehensive list of all items that can be added to the  **
 	* A **key** that is the unique identifier for the item. Dashes (-'s) are preferred to underscores (_'s).
 	* A **name** that is the plain-text label for the identifier. You have to tell your users what they are filling out.
 	* **required** is a boolean to specify whether the user has to fill this item out in order to use the module.
-	* **type** is the data type. Can be: text
-		* json
+	* **type** is the data type. Available options are: 
+		* text
 		* textarea
+		* descriptive
+		* json
 		* rich-text
 		* field-list
 		* user-role-list
@@ -423,6 +425,11 @@ For reference, below is a nearly comprehensive example of the types of things th
    ],
 
    "project-settings": [
+      {
+         "key": "descriptive-text",
+         "name": "This is just a descriptive field with only static text and no input field.",
+         "type": "descriptive"
+      },
       {
          "key": "instructions-field",
          "name": "Instructions text box",

--- a/manager/js/globals.js
+++ b/manager/js/globals.js
@@ -127,6 +127,11 @@ ExternalModules.Settings.prototype.getColumnHtml = function(setting,value,classN
 		className = "";
 	}
 	var trClass = className;
+	
+	var colspan = '';
+	if(type == 'descriptive'){
+		colspan = " colspan='3'";
+	}
 
 	var instanceLabel = "";
 	if (typeof instance != "undefined") {
@@ -134,7 +139,7 @@ ExternalModules.Settings.prototype.getColumnHtml = function(setting,value,classN
 	}
 	var html = "<td></td>";
 	if(type != 'sub_settings') {
-		html = "<td><span class='external-modules-instance-label'>" + instanceLabel + "</span><label>" + setting.name + ":</label></td>";
+		html = "<td" + colspan + "><span class='external-modules-instance-label'>" + instanceLabel + "</span><label>" + setting.name + (type == 'descriptive' ? '' : ':') + "</label></td>";
 	}
 
 	if (typeof instance != "undefined") {
@@ -218,9 +223,11 @@ ExternalModules.Settings.prototype.getColumnHtml = function(setting,value,classN
 
 		inputHtml = this.getInputElement(type, key, value, inputAttributes);
 	}
-
-	html += "<td class='external-modules-input-td'>" + inputHtml + "</td>";
-
+	
+	if(type != 'descriptive'){
+		html += "<td class='external-modules-input-td'>" + inputHtml + "</td>";
+	}
+	
 	if(setting.repeatable) {
 		// Add repeatable buttons
 		html += "<td class='external-modules-add-remove-column'>";


### PR DESCRIPTION
Adding new configuration field type: descriptive. Just like in REDCap, it displays only text with no input field.