### PR TITLE
Discoverable setting bug

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -2463,12 +2463,15 @@ class ExternalModules
 	public static function getDiscoverableModules()
 	{
 		$modules = array();
-		$sql = "select m.directory_prefix from redcap_external_module_settings s, redcap_external_modules m
+		$sql = "select m.directory_prefix, x.`value` from redcap_external_modules m, 
+				redcap_external_module_settings s, redcap_external_module_settings x
 				where m.external_module_id = s.external_module_id and s.project_id is null
-				and `value` = 'true' and `key` = '".db_escape(self::KEY_DISCOVERABLE)."'";
+				and s.`value` = 'true' and s.`key` = '".db_escape(self::KEY_DISCOVERABLE)."'
+                and m.external_module_id = x.external_module_id and x.project_id is null
+				and x.`key` = '".db_escape(self::KEY_VERSION)."'";
 		$q = db_query($sql);
 		while ($row = db_fetch_assoc($q)) {
-			$modules[] = $row['directory_prefix'];
+			$modules[$row['directory_prefix']] = $row['value'];
 		}
 		return $modules;
 	}

--- a/manager/ajax/get-disabled-modules.php
+++ b/manager/ajax/get-disabled-modules.php
@@ -7,9 +7,8 @@ require_once dirname(dirname(dirname(__FILE__))) . '/classes/ExternalModules.php
 <table id='external-modules-disabled-table' class="table table-no-top-row-border">
 	<?php
 
-	$enabledModules = ExternalModules::getEnabledModules();
-
 	if (!isset($_GET['pid'])) {
+		$enabledModules = ExternalModules::getEnabledModules();
 		$disabledModuleConfigs = ExternalModules::getDisabledModuleConfigs($enabledModules);
 
 		if (empty($disabledModuleConfigs)) {
@@ -53,6 +52,12 @@ require_once dirname(dirname(dirname(__FILE__))) . '/classes/ExternalModules.php
 			}
 		}
 	} else {
+		// Only get modules that have been made discoverable (but if a super user, display all)
+		if (SUPER_USER) {
+			$enabledModules = ExternalModules::getEnabledModules();
+		} else {
+			$enabledModules = ExternalModules::getDiscoverableModules();
+		}
 		foreach ($enabledModules as $prefix => $version) {
 			$config = ExternalModules::getConfig($prefix, $version, $_GET['pid']);
 			$enabled = ExternalModules::getProjectSetting($prefix, $_GET['pid'], ExternalModules::KEY_ENABLED);

--- a/manager/templates/enabled-modules.php
+++ b/manager/templates/enabled-modules.php
@@ -140,7 +140,6 @@ if (version_compare(PHP_VERSION, ExternalModules::MIN_PHP_VERSION, '<')) {
 $displayModuleDialogBtn = (SUPER_USER || ExternalModules::hasDiscoverableModules());
 $moduleDialogBtnText = SUPER_USER ? "Enable a module" : "View available modules";
 $moduleDialogBtnImg = SUPER_USER ? "glyphicon-plus-sign" : "glyphicon-info-sign";
-$discoverableModules = ExternalModules::getDiscoverableModules();
 
 ?>
 <br>


### PR DESCRIPTION
Bug fix: The "discoverable" setting for modules (set in the Control Center for a given module) was not quite working correctly, in which a regular user could navigate to the Project Module Manager page in their project and view *all* modules that have been enabled in the system, when instead they should only be able to view the modules that have been made discoverable.