### PR TITLE
Fix issue with isManagerUrl()

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -726,7 +726,7 @@ class ExternalModules
 
 	private static function isManagerUrl()
 	{
-		$currentUrl = $_SERVER['REQUEST_SCHEME'] . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		$currentUrl = (SSL ? "https" : "http") . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 		return strpos($currentUrl, self::$BASE_URL . 'manager') !== false;
 	}
 


### PR DESCRIPTION
Fix issue with isManagerUrl() using a server variable that is dependent upon Apache and also on specific versions of Apache