### PR TITLE
do not show the external mod panel if there are no visible links

### DIFF
--- a/manager/templates/hooks/every_page_top.php
+++ b/manager/templates/hooks/every_page_top.php
@@ -82,8 +82,8 @@ $getIcon = function ($icon){
 				}
 			}
 			?>
-
-			newPanel.insertBefore('#help_panel')
+            // Only render the newPanel if the menubox contains links
+			if (menubox.children().length) newPanel.insertBefore('#help_panel')
 		}
 	})
 </script>


### PR DESCRIPTION
with the redcap_module_link_check_display hook, it is possible that the links defined are all being hidden - in which case we shouldn't display the external modules panel at all on the sidebar.