### PR TITLE
Made getSubSettings() work with nested sub settings

### DIFF
--- a/tests/AbstractExternalModuleTest.php
+++ b/tests/AbstractExternalModuleTest.php
@@ -1041,35 +1041,60 @@ class AbstractExternalModuleTest extends BaseTest
 
 			// These settings each intentionally have difference lengths to make sure they're still returned appropriately.
 			'key2' => ['a', 'b', 'c'],
-			'key3' => [1,2,3,4,5],
-			'key4' => [true, false]
+			'key3' => [1, 2, 3, 4, 5],
+			'key4' => [true, false],
+			'key5' => [6,7,8,9]
 		];
 
-		$subSettingsConfig = [];
 		foreach($settingValues as $key=>$values){
 			$m->setProjectSetting($key, $values);
-
-			$subSettingsConfig[] = [
-				'key' => $key
-			];
 		}
 
 		$subSettingsKey = 'sub-settings-key';
+		$nestedSubSettingsKey = 'nested-sub-settings-key';
+
 		$this->setConfig([
 			'project-settings' => [
 				[
 					'key' => $subSettingsKey,
 					'type' => 'sub_settings',
-					'sub_settings' => $subSettingsConfig
+					'sub_settings' => [
+						[
+							'key' => 'key1'
+						],
+						[
+							'key' => 'key2'
+						],
+						[
+							'key' => 'key3'
+						],
+						[
+							'key' => 'key4'
+						],
+						[
+							'key' => $nestedSubSettingsKey,
+							'type' => 'sub_settings',
+							'sub_settings' => [
+								[
+									'key' => 'key5'
+								]
+							]
+						],
+					]
 				]
 			]
 		]);
 
-		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $settingValues) {
+		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $nestedSubSettingsKey, $settingValues) {
 			$subSettingResults = $m->getSubSettings($subSettingsKey, $pid);
 			foreach($settingValues as $key=>$values){
 				for($i=0; $i<count($values); $i++){
-					$this->assertSame($settingValues[$key][$i], $subSettingResults[$i][$key]);
+					$actualValues = $subSettingResults[$i];
+					if($key === 'key5'){
+						$actualValues = $actualValues[$nestedSubSettingsKey];
+					}
+					
+					$this->assertSame($settingValues[$key][$i], $actualValues[$key]);
 				}
 			}
 		};


### PR DESCRIPTION
I believe this change should be fully backward compatible as verified by the unit test.  @kcmcg, would you be be able to check me on that?

@tmwil and @tbembersimeao, you may want to review this since I believe you both implemented something similar about a year ago in your respective projects.  I think we just never replaced the getSubSettings() implementation because we weren't sure about the backward compatibility of those implementations.  I ran into this again on my current project and was hoping to solve it once and for all.  Do you think this solution would work for similar cases going forward?

@Pyronaught, don't feel obligated to dig into the details of what's going on here unless you want to.  I mainly thought you'd be curious.