### PR TITLE
Take two on making getSubSettings() work with nested sub settings

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -883,12 +883,17 @@ class ExternalModules
 		return strpos($currentUrl, self::$BASE_URL . 'manager') !== false;
 	}
 
+	public static function getLockName($moduleId, $projectId)
+	{
+		return db_real_escape_string("external-module-setting-$moduleId-$projectId");
+	}
+
 	# this is a helper method
 	# call set [System,Project] Setting instead of calling this method
 	private static function setSetting($moduleDirectoryPrefix, $projectId, $key, $value, $type = "")
 	{
 		$externalModuleId = self::getIdForPrefix($moduleDirectoryPrefix);
-		$lockName = db_real_escape_string("external-module-setting-$externalModuleId-$projectId");
+		$lockName = self::getLockName($externalModuleId, $projectId);
 
 		// The natural solution to prevent duplicates would be a unique key.
 		// That unfortunately doesn't work for the settings table since the total length of the appropriate key columns is longer than the maximum unique key length.

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -3273,4 +3273,25 @@ class ExternalModules
 			throw new Exception("The following action has been throttled because it is only allowed to happen $maximumOccurrences times within $seconds seconds, but it happened $occurrences times: $description");
 		}
 	}
+
+	// Copied from the first comment here:
+	// http://php.net/manual/en/function.array-merge-recursive.php
+	function array_merge_recursive_distinct ( array &$array1, array &$array2 )
+	{
+	  $merged = $array1;
+
+	  foreach ( $array2 as $key => &$value )
+	  {
+	    if ( is_array ( $value ) && isset ( $merged [$key] ) && is_array ( $merged [$key] ) )
+	    {
+	      $merged [$key] = self::array_merge_recursive_distinct ( $merged [$key], $value );
+	    }
+	    else
+	    {
+	      $merged [$key] = $value;
+	    }
+	  }
+
+	  return $merged;
+	}
 }

--- a/tests/AbstractExternalModuleTest.php
+++ b/tests/AbstractExternalModuleTest.php
@@ -1109,4 +1109,68 @@ class AbstractExternalModuleTest extends BaseTest
 
 		$assertSubSettings($pid);
 	}
+
+	function testGetSubSettings_complexNesting()
+	{
+		$m = $this->getInstance();
+		$_GET['pid'] = 1;
+
+		// This json file can be copied into a module for hands on testing/modification via the settings dialog.
+		$this->setConfig(json_decode(file_get_contents(__DIR__ . '/complex-nested-settings.json'), true));
+
+		// These values were copied directly from the database after saving them through the settings dialog (as configured by the json file above).
+		$m->setProjectSetting('countries', ["true","true"]);
+		$m->setProjectSetting('country-name', ["USA","Canada"]);
+		$m->setProjectSetting('states', [["true","true"],["true"]]);
+		$m->setProjectSetting('state-name', [["Tennessee","Alabama"],["Ontario"]]);
+		$m->setProjectSetting('cities', [[["true","true"],["true"]],[["true"]]]);
+		$m->setProjectSetting('city-name', [[["Nashville","Franklin"],["Huntsville"]],[["Toronto"]]]);
+		$m->setProjectSetting('city-size', [[["large","small"],["medium"]],[["large"]]]);
+
+		$expectedCountries = [
+			[
+				"states" => [
+					[
+						"state-name" => "Tennessee",
+						"cities" => [
+							[
+								"city-name" => "Nashville",
+								"city-size" => "large"
+							],
+							[
+								"city-name" => "Franklin",
+								"city-size" => "small"
+							]
+						]
+					],
+					[
+						"state-name" => "Alabama",
+						"cities" => [
+							[
+								"city-name" => "Huntsville",
+								"city-size" => "medium"
+							]
+						]
+					]
+				],
+				"country-name" => "USA"
+			],
+			[
+				"states" => [
+					[
+						"state-name" => "Ontario",
+						"cities" => [
+							[
+								"city-name" => "Toronto",
+								"city-size" => "large"
+							]
+						]
+					]
+				],
+				"country-name" => "Canada"
+			]
+		];
+
+		$this->assertEquals($expectedCountries, $m->getSubSettings('countries'));
+	}
 }

--- a/tests/AbstractExternalModuleTest.php
+++ b/tests/AbstractExternalModuleTest.php
@@ -1041,60 +1041,35 @@ class AbstractExternalModuleTest extends BaseTest
 
 			// These settings each intentionally have difference lengths to make sure they're still returned appropriately.
 			'key2' => ['a', 'b', 'c'],
-			'key3' => [1, 2, 3, 4, 5],
-			'key4' => [true, false],
-			'key5' => [6,7,8,9]
+			'key3' => [1,2,3,4,5],
+			'key4' => [true, false]
 		];
 
+		$subSettingsConfig = [];
 		foreach($settingValues as $key=>$values){
 			$m->setProjectSetting($key, $values);
+
+			$subSettingsConfig[] = [
+				'key' => $key
+			];
 		}
 
 		$subSettingsKey = 'sub-settings-key';
-		$nestedSubSettingsKey = 'nested-sub-settings-key';
-
 		$this->setConfig([
 			'project-settings' => [
 				[
 					'key' => $subSettingsKey,
 					'type' => 'sub_settings',
-					'sub_settings' => [
-						[
-							'key' => 'key1'
-						],
-						[
-							'key' => 'key2'
-						],
-						[
-							'key' => 'key3'
-						],
-						[
-							'key' => 'key4'
-						],
-						[
-							'key' => $nestedSubSettingsKey,
-							'type' => 'sub_settings',
-							'sub_settings' => [
-								[
-									'key' => 'key5'
-								]
-							]
-						],
-					]
+					'sub_settings' => $subSettingsConfig
 				]
 			]
 		]);
 
-		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $nestedSubSettingsKey, $settingValues) {
+		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $settingValues) {
 			$subSettingResults = $m->getSubSettings($subSettingsKey, $pid);
 			foreach($settingValues as $key=>$values){
 				for($i=0; $i<count($values); $i++){
-					$actualValues = $subSettingResults[$i];
-					if($key === 'key5'){
-						$actualValues = $actualValues[$nestedSubSettingsKey];
-					}
-					
-					$this->assertSame($settingValues[$key][$i], $actualValues[$key]);
+					$this->assertSame($settingValues[$key][$i], $subSettingResults[$i][$key]);
 				}
 			}
 		};

--- a/tests/AbstractExternalModuleTest.php
+++ b/tests/AbstractExternalModuleTest.php
@@ -1041,35 +1041,60 @@ class AbstractExternalModuleTest extends BaseTest
 
 			// These settings each intentionally have difference lengths to make sure they're still returned appropriately.
 			'key2' => ['a', 'b', 'c'],
-			'key3' => [1,2,3,4,5],
-			'key4' => [true, false]
+			'key3' => [1, 2, 3, 4, 5],
+			'key4' => [true, false],
+			'key5' => [6,7,8,9]
 		];
 
-		$subSettingsConfig = [];
 		foreach($settingValues as $key=>$values){
 			$m->setProjectSetting($key, $values);
-
-			$subSettingsConfig[] = [
-				'key' => $key
-			];
 		}
 
 		$subSettingsKey = 'sub-settings-key';
+		$nestedSubSettingsKey = 'nested-sub-settings-key';
+
 		$this->setConfig([
 			'project-settings' => [
 				[
 					'key' => $subSettingsKey,
 					'type' => 'sub_settings',
-					'sub_settings' => $subSettingsConfig
+					'sub_settings' => [
+						[
+							'key' => 'key1'
+						],
+						[
+							'key' => 'key2'
+						],
+						[
+							'key' => 'key3'
+						],
+						[
+							'key' => 'key4'
+						],
+						[
+							'key' => $nestedSubSettingsKey,
+							'type' => 'sub_settings',
+							'sub_settings' => [
+								[
+									'key' => 'key5'
+								]
+							]
+						],
+					]
 				]
 			]
 		]);
 
-		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $settingValues) {
+		$assertSubSettings = function($pid) use ($m, $subSettingsKey, $nestedSubSettingsKey, $settingValues) {
 			$subSettingResults = $m->getSubSettings($subSettingsKey, $pid);
 			foreach($settingValues as $key=>$values){
 				for($i=0; $i<count($values); $i++){
-					$this->assertSame($settingValues[$key][$i], $subSettingResults[$i][$key]);
+					$actualValues = $subSettingResults[$i];
+					if($key === 'key5'){
+						$actualValues = $actualValues[$nestedSubSettingsKey];
+					}
+					
+					$this->assertSame($settingValues[$key][$i], $actualValues[$key]);
 				}
 			}
 		};

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -48,13 +48,9 @@ abstract class BaseTest extends TestCase
 		$this->setConfig([]);
 		$this->getInstance()->testHookArguments = null;
 
-		$this->removeSystemSetting();
-		$this->removeProjectSetting();
-
 		$m = self::getInstance();
-		$m->removeSystemSetting(ExternalModules::KEY_VERSION, TEST_SETTING_PID);
-		$m->removeSystemSetting(ExternalModules::KEY_ENABLED, TEST_SETTING_PID);
-		$m->removeProjectSetting(ExternalModules::KEY_ENABLED, TEST_SETTING_PID);
+		$moduleId = ExternalModules::getIdForPrefix(TEST_MODULE_PREFIX);
+		$m->query("delete from redcap_external_module_settings where external_module_id = $moduleId");
 
 		$_GET = [];
 		$_POST = [];

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -50,7 +50,11 @@ abstract class BaseTest extends TestCase
 
 		$m = self::getInstance();
 		$moduleId = ExternalModules::getIdForPrefix(TEST_MODULE_PREFIX);
+		$lockName = ExternalModules::getLockName($moduleId, TEST_SETTING_PID);
+
+		$m->query("SELECT GET_LOCK('$lockName', 5)");
 		$m->query("delete from redcap_external_module_settings where external_module_id = $moduleId");
+		$m->query("SELECT RELEASE_LOCK('$lockName')");
 
 		$_GET = [];
 		$_POST = [];

--- a/tests/complex-nested-settings.json
+++ b/tests/complex-nested-settings.json
@@ -1,0 +1,48 @@
+{
+	"project-settings": [
+		{
+			"key": "countries",
+			"name": "Country",
+			"type": "sub_settings",
+			"repeatable": true,
+			"sub_settings": [
+				{
+					"key": "states",
+					"name": "State",
+					"type": "sub_settings",
+					"repeatable": true,
+					"sub_settings": [
+						{
+							"key": "state-name",
+							"name": "State Name",
+							"type": "text"
+						},
+						{
+							"key": "cities",
+							"name": "City",
+							"type": "sub_settings",
+							"repeatable": true,
+							"sub_settings": [
+								{
+									"key": "city-name",
+									"name": "City Name",
+									"type": "text"
+								},
+								{
+									"key": "city-size",
+									"name": "City Size",
+									"type": "text"
+								}
+							]
+						}
+					]
+				},
+				{
+					"key": "country-name",
+					"name": "Country Name (on the bottom just to test a different order)",
+					"type": "text"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
I fixed issue I found after the first PR.  I believe this change should be fully backward compatible as verified by the unit test. @kcmcg, would you be be able to check me on that?

@tmwil and @tbembersimeao, you may want to review this since I believe you both implemented something similar about a year ago in your respective projects. I think we just never replaced the getSubSettings() implementation because we weren't sure about the backward compatibility of those implementations. I ran into this again on my current project and was hoping to solve it once and for all. Do you think this solution would work for similar cases going forward?

@Pyronaught, don't feel obligated to dig into the details of what's going on here unless you want to. I mainly thought you'd be curious.