### PR TITLE
Allow exit

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -94,6 +94,8 @@ class ExternalModules
 	
 	private static $deletedModules;
 
+	private static $allowExit;
+	
 	private static $configs = array();
 
 	# two reserved settings that are there for each project
@@ -327,6 +329,11 @@ class ExternalModules
 				return;
 			}
 
+			if (self::$allowExit) {
+                		// Ignore the shutdown function if this module is allowed to exit()
+            			return;
+            		}
+			
 			if($error && $error['type'] === E_NOTICE){
 				// This is just a notice, which likely means it occurred BEFORE an offending die/exit call.
 				// Ignore this notice and show the general die/exit call warning instead.
@@ -1384,6 +1391,10 @@ class ExternalModules
 			if(method_exists($instance, $thisHook)){
 				self::setActiveModulePrefix($prefix);
 
+			    	// Check if we should allow exit in the shutdown function for this hook
+		                $config = self::getConfig($prefix,$version);
+                		self::$allowExit = (isset($config['allow-exit']) && in_array($thisHook, $config['allow-exit']));
+				
 				// Buffer output so we can access for killed query detection using register_shutdown_function().
 				ob_start();
 

--- a/docs/official-documentation.md
+++ b/docs/official-documentation.md
@@ -217,6 +217,11 @@ By default, every page hooks will only execute on project specific pages (and on
 
 `"enable-every-page-hooks-on-system-pages": true`
 
+##### Exiting From a Hook Method
+In general, hook functions should `return;` when complete.  If you leave a hook with an `exit();` statement an error will be thrown as this prevents other external modules that might use this hook method from being called.  There are two alternate methods for exiting either after or during a hook.  First, you can call `$this->exitAfterHook();` from your module which will wait until all EMs running that hook have completed and will then exit, preventing further downstream hooks from being called.  This can be useful, for example, when trying to suppress normal output with an `every_page_before_render` hook.  A second option is to add the `allow-exit` key to your config.json and supply an array of hook functions where exit will be permitted for this external module.  This method is potentially dangerous as it will prevent other external modules that might use the same method from running if they came after the method calling exit.  An example is below that would permit you to call `exit();` from the redcap_custom_verify_username hook to prevent the normal display of user rights information:
+
+`"allow-exit": [ 'redcap_custom_verify_username' ]`
+
 ##### Extra hooks provided by External Modules
 There are a few extra hooks dedicated for modules use:
 


### PR DESCRIPTION
Adding ability to force exit from inside an EM hook - required to get redcap_custom_verify_username to work without the ability to pass return parameters.  This is also relevant to #89 for @lsgs and @mmcev106 .

Inside my config.json
```
  "allow-exit": [
    "redcap_cuxstom_verify_username"
  ],
```

Inside my EM hook:
```
public function redcap_custom_verify_username($username) {
    ....
    // Previously with this hook, you returned $status and $message, but now you have to render the results yourself.
    if ($status) {
        if (strlen($message) > 0) {
            echo "<div class='alert alert-success text-center'>" . $message . "</div>";
        }
    } else {
        echo "<div class='alert alert-danger text-center'>" . $message . "</div>";
        exit();  // This prevents the rendering of the rest of the user rights page...
    }
}
```