### PR TITLE
refactored to allow return values

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1514,6 +1514,9 @@ class ExternalModules
 				self::$delayed[self::$hookBeingExecuted] = array();
 				self::$delayedLastRun = $lastRun;
 				foreach ($prevDelayed as $prefix=>$version) {
+					// Modules that call delayModuleExecution() normally just "return;" afterward, effectively returning null.
+					// However, they could potentially return a value after delaying, which would result in multiple entries in $resultsByPrefix for the same module.
+					// This could cause filterHookResults() to trigger unnecessary warning emails, but likely won't be an issue in practice.
 					$startHook($prefix, $version);
 				}
 			};

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -96,8 +96,6 @@ class ExternalModules
 
 	private static $configs = array();
 
-	private static $returnValues = array();
-
 	# two reserved settings that are there for each project
 	# KEY_VERSION, if present, denotes that the project is enabled system-wide
 	# KEY_ENABLED is present when enabled for each project

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -96,6 +96,8 @@ class ExternalModules
 
 	private static $configs = array();
 
+	private static $returnValues = array();
+
 	# two reserved settings that are there for each project
 	# KEY_VERSION, if present, denotes that the project is enabled system-wide
 	# KEY_ENABLED is present when enabled for each project
@@ -1342,10 +1344,18 @@ class ExternalModules
 		return "(" . implode(" OR ", $parts) . ")";
 	}
 
-	# begins the execution of a hook
-	# helper method
-	# should call callHook
-	private static function startHook($prefix, $version, $arguments) {	
+    /**
+     * begins execution of hook
+     * helper method
+     * should call callHook
+     *
+     * @param $prefix
+     * @param $version
+     * @param $arguments
+     * @return mixed|void|null  result from hook or null
+     * @throws Exception
+     */
+    private static function startHook($prefix, $version, $arguments) {
 		
 		// Get the hook's root name
 		if (substr(self::$hookBeingExecuted, 0, 5) == 'hook_') {
@@ -1379,7 +1389,9 @@ class ExternalModules
 
 		$instance = self::getModuleInstance($prefix, $version);
 		$instance->setRecordId($recordId);
-		
+
+		$result = null; // Default result value
+
 		foreach ($hookNames as $thisHook) {
 			if(method_exists($instance, $thisHook)){
 				self::setActiveModulePrefix($prefix);
@@ -1388,7 +1400,7 @@ class ExternalModules
 				ob_start();
 
 				try{
-					call_user_func_array(array($instance,$thisHook), $arguments);
+					$result = call_user_func_array(array($instance,$thisHook), $arguments);
 				}
 				catch(Exception $e){
 					$message = "The '" . $prefix . "' module threw the following exception when calling the hook method '".$thisHook."':\n\n" . $e;
@@ -1404,6 +1416,8 @@ class ExternalModules
 		}
 
 		$instance->setRecordId(null);
+
+        return $result;
 	}
 
 	private static function getProjectIdFromHookArguments($arguments)
@@ -1443,6 +1457,9 @@ class ExternalModules
 		 */
 		self::getSystemwideEnabledVersions();
 
+		# Hold results for hooks that return a value
+		$resultsByPrefix = array();
+
 		try {
 			if(!defined('PAGE')){
 				$page = ltrim($_SERVER['REQUEST_URI'], '/');
@@ -1476,7 +1493,14 @@ class ExternalModules
 			}
 
 			foreach($versionsByPrefix as $prefix=>$version){
-				self::startHook($prefix, $version, $arguments);
+				$result = self::startHook($prefix, $version, $arguments);
+			    if (!empty($result) && is_array($result)) {
+                    // Lets preserve order of execution by order entered into the results array
+			        $resultsByPrefix[] = array(
+                        "prefix" => $prefix,
+                        "result" => $result
+                    );
+                }
 			}
 
 			$callDelayedHooks = function($lastRun) use ($arguments){
@@ -1484,7 +1508,13 @@ class ExternalModules
 				self::$delayed[self::$hookBeingExecuted] = array();
 				self::$delayedLastRun = $lastRun;
 				foreach ($prevDelayed as $prefix=>$version) {
-					self::startHook($prefix, $version, $arguments);
+					$result = self::startHook($prefix, $version, $arguments);
+    			    if (!empty($result) && is_array($result)) {
+    			        $resultsByPrefix[] = array(
+                            "prefix" => $prefix,
+                            "result" => $result
+                        );
+                    }
 				}
 			};
 	
@@ -1511,10 +1541,48 @@ class ExternalModules
 			}
 		}
 
+        // As this is currently written, any function that returns a value cannot also exit.
+        // TODO: Should we move this to a shutdown function for this hook so we can return a value?
 		if(self::$exitAfterHook){
 			exit();
 		}
+
+		// We must resolve cases where there are multiple return values.
+        // We can assume we only support a single return value (easier) or we can expand our definition of hooks
+        // to handle multiple return values as an array of values.  For now, let's shoot simple and just take
+        // the latest one and throw a warning to the admin
+		return self::filterHookResults($resultsByPrefix, $name);
 	}
+
+    /**
+     * Handle cases where there are multiple results for a hook
+     * @param $results     | An array where each element is a result array from an EM with keys 'result' and 'prefix'
+     * @param $hookName    | The hook where the results were generated.
+     * @return array|null
+     */
+	private static function filterHookResults($results, $hookName) {
+        if (empty($results)) return null;
+
+        // Take the last result
+        end($results);
+        $last_result = current($results);
+
+        // Throw a warning if there is more than one result
+        if (count($results) > 1) {
+            $message =  "<p>" . count($results) . " return values were generated from hook $hookName " .
+                "by the following external modules:</p>";
+            foreach ($results as $result) {
+                $message .= "<p><b><u>{$result['prefix']}</u></b> => <code>" . htmlentities(json_encode($result['result'])) . "</code></div></p>";
+            }
+            $message .= "<p>Only the last result from <b><u>" . $last_result['prefix'] . "</u></b> will be used " .
+                "by REDCap.  Consider disabling or refactoring the other external modules so this does not occur.</p>";
+
+            ExternalModules::sendAdminEmail("REDCap External Module Results Warning", $message);
+        }
+
+        return $last_result['result'];
+    }
+
 
 	public static function exitAfterHook(){
 		self::$exitAfterHook = true;


### PR DESCRIPTION
Here is an update to External Modules that supports return values.  It takes the approach that the last one wins.   Also, if there are return values from both EM hooks and 'non-em' function-based hooks, it takes the approach that the function-based hook wins.  This is debatable, but for now it is a start.  If we wanted we could try to allow multiple return values and handle the processing on the actual hook functions, but that seems like a leap when we don't have a good use case.

One issue that needs resolve is the exitAfterHook call.  Currently, if a hook has 'exitAfterHook' enabled, it happens before the return value is sent.  I'm guessing this may be okay as how can you process a return value AND exit after hook?  Seems a little hard.

If two EMs try to return a value for the same hook, it will throw a warning email to the admins, something like:

```
[This message was automatically generated by REDCap]

2 return values were generated from hook custom_verify_username by the following external modules:

1 admin_ninja: {"status":false,"0":"message","1":"SOMETHING ELSE"}
1 username_verification: {"status":false,"message":"The specified SUNet ID, <b><u>asdfsadfsa<\/u><\/b>, does not appear to be valid.<br\/><br\/> Many users have email aliases (e.g. Jane.Doe@stanford.edu) where the email prefix is not the same as their SUNet ID. A SUNet ID should be 8 characters or less without any periods or hyphens.<br\/><br\/>Try searching the <a href='https:\/\/stanford.rimeto.io\/search\/asdfsadfsa' target='_BLANK'> <div class='btn btn-xs btn-danger'><b>Stanford Directory<\/b><\/div><\/a> or contact your collaborator to obtain their SUNet ID."}
Only the last result from username_verification value will be returned to REDCap for processing by the hook function. Consider disabling or refactoring the other external modules so this does not occur.

URL: http://localhost/redcap_v8.9.3/UserRights/edit_user.php?pid=21
Server: localhost (2db2d4c7bc82)
User: andy123
```


It also requires an update to the `Hooks.php` class in REDCap.
```
	// Call a REDCap Hook function
	public static function call($function_name, $params=array())
	{
		// If not a real hook method in this class, then return
		if (!method_exists(__CLASS__, $function_name)) return false;

		// Call External Modules method before calling the native hook in the hook functions file
		if (defined("APP_PATH_EXTMOD")) {
			$em_result = \ExternalModules\ExternalModules::callHook($function_name, $params);
		}

		// Evaluate hook from hook_functions.php file if present
		if (function_exists($function_name)) {
			// Call the hook function
			$func_result = call_user_func_array($function_name, $params);
		}

		// We have to decide how to handle collisions where both the EM AND the hook function return a value
		// For now, I'll let the local function override the EM as any local hook function has to be
		// explicitly set up by the owner of the redcap instance
		$result = !empty($em_result)   && is_array($em_result)   ? $em_result   : false;
		$result = !empty($func_result) && is_array($func_result) ? $func_result : $result;

		// Call the appropriate method to process the return values, then return anything returned by the custom function
		return call_user_func_array(__CLASS__ . '::' . $function_name, array($result));
	}
```

While we are at it, I'd like to also do a minor update to the redcap_custom_verify_username hook:

```
	public static function redcap_custom_verify_username($result)
	{
		// If a message is returned, then output the message in a colored div
		if (isset($result['message']) && !empty($result['message'])) {
			// Set the color for the message based on the status
			$colorClass = $result['status'] ? 'green' : 'red';
			print RCView::div(array('class'=>$colorClass, 'style'=>'margin:10px 0;'), $result['message']);

			// If status is FALSE, then stop script execution
			if (isset($result['status']) && ($result['status'] === false)) exit;
		}
		// Don't return anything
	}
```
