### PR TITLE
Language (Translation) feature for the EM Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /vendor
+/.vscode

--- a/classes/AbstractExternalModule.php
+++ b/classes/AbstractExternalModule.php
@@ -1257,6 +1257,11 @@ class AbstractExternalModule
 			return call_user_func_array([$this, 'log_internal'], $arguments);
 		}
 
+		// Forward translation support function to the framework.
+		if ($name == "tt" && isset($this->framework) && method_exists($this->framework, $name)) {
+			return call_user_func_array([$this->framework, $name], $arguments);
+		}
+
 		throw new Exception("The following method does not exist: $name()");
 	}
 

--- a/classes/framework/v2/Framework.php
+++ b/classes/framework/v2/Framework.php
@@ -21,6 +21,77 @@ class Framework
 		$this->records = new Records($module);
 	}
 
+	//region Language features
+
+	/**
+	 * Returns the translation for the given language file key.
+	 * 
+	 * @param string $key The language file key.
+	 * @param mixed $values The values to be used for interpolation. If the first parameter is a (sequential) array, it's members will be used and any further parameters ignored.
+	 * 
+	 * @return string The translation (with interpolations).
+	 */
+	public function tt($key, ...$values) {
+		
+		global $lang;
+
+		// Get the full key for $lang.
+		$lang_key = ExternalModules::constructLanguageKey($this->module->PREFIX, $key);
+		// Now get the corresponding text.
+		$text = $lang[$lang_key];
+
+		// Do we need to do interpolation?
+		if (count($values)) {
+			// Use array if supplied. 
+			if (is_array($values[0])) $values = $values[0];
+			// Regular expression to find places where replacements need to be done.
+			// Placeholers are in curly braces, e.g. {0}. Optionally, a type hint can be present after a colon (e.g. {0:Date}) which is ignored however.
+			// To not replace a placeholder, the first curly can be escaped with a backslash like so: '\{1}' (this will leave '{1}' in the text).
+			// When the an even number of backslashes is before the curly, e.g. '\\{0}' with value x this will result in '\x'.
+			// Placeholder names can be strings (a-Z0-9_), too (need associative array then). 
+			$re = '/(?\'all\'((?\'escape\'\\\\*){|{)(?\'index\'[\d_A-Za-z]+)(:(?\'hint\'.*))?})/mU';
+			preg_match_all($re, $text, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE, 0);
+			// Build resulting string.
+			$prevEnd = 0;
+			if (count($matches)) {
+				$result = "";
+				foreach ($matches as $match) {
+					$start = $match["all"][1];
+					$all = $match["all"][0];
+					$len = strlen($all);
+					$key = $match["index"][0];
+					// Add text between previous end and the match and reset end.
+					$result .= substr($text, $prevEnd, $start - $prevEnd);
+					$prevEnd = $start + $len;
+					// Escaped?
+					$nSlashes = strlen($match["escape"][0]);
+					if ($nSlashes % 2 == 0) {
+						// Even number means they escaped themselves, so we add half of them and replace.
+						$result .= str_repeat("\\", $nSlashes / 2);
+						if (array_key_exists($key, $values)) {
+							$result .= $values[$key];
+						}
+						else {
+							// When the key doesn't exist, just leave it unchanged (but remove the backslashes).
+							$result .= ltrim($all, "\\");
+						}
+					}
+					else {
+						// Uneven number - means to not replace.
+						$result .= str_repeat("\\", ($nSlashes - 1) / 2);
+						$result .= ltrim($all, "\\");
+					}
+				}
+				// Add rest of original.
+				$result .= substr($text, $prevEnd);
+				$text = $result;
+			}
+		}
+		return $text;
+	}
+
+	//endregion
+
 	function getProjectsWithModuleEnabled(){
 		$results = $this->query("
 			select project_id


### PR DESCRIPTION
## Hey guys,

So, I did it ... as briefly discussed with Mark [over at the community site](https://community.projectredcap.org/questions/45861/how-to-do-internationalization-and-localization-in.html?childToView=62740#comment-62740). I have added support for INI-Style language files for External Modules, similar to how REDCap core does it.
The implementation is totally transparant for existing modules. To use the new features, they have to opt. Strings ("name", "description" fields) can be translated without breaking backward compatibility. To use the language feature in module code (via a tt() function) will require the EM framework version 2 and REDCap >= where the language feature is implemented (so 9.0.1 the earliest ;).

## How does it work? 
- Add a "lang" folder with translation files (such as English.ini) into the EM's folder
- To translate config stuff, add "tt_name" or "tt_description" fields containing the key from the language file.
- To translate text in module code, use the tt() function provided by the framework version 2 (I added a forwarding from AbstractExternalModule via __call). Call as tt($key) or tt($key, $value1, $value2, ...) or tt($key, $valueArray) to get string interpolation, e.g. when the text corresponding to the key is e.g. "{0} are {1}." and $values = array("Apples", "red") this will give "Apples are red.". tt($key) without values would just pass through the original string (nice when interpolation happens in the browser).

## What is missing? 
- A corresponding JS function replicating tt for interpolation in the browser. I will work on this asap.

## How does this look in a module?
- Head over to the [nedCAPTCHA](https://github.com/grezniczek/redcap_nedcaptcha/tree/langfeature) external module and have a look, focus on the lang directory and on config.json. Use of tt() is made in NEDCaptchaExternalModule.php around line 600. Complete English and German translations are available (I should have picked another module to showcase this ... there was a LOT to translate).
- Install it with the update EM framework to see it in action.

*Let me know what you think!*

Cheers,
GR
