### PR TITLE
small fix for getSubSettings() function inside the Absct…

### DIFF
--- a/classes/AbstractExternalModule.php
+++ b/classes/AbstractExternalModule.php
@@ -269,8 +269,7 @@ class AbstractExternalModule
 		foreach($config['sub_settings'] as $subSetting){
 			$keys[] = $this->prefixSettingKey($subSetting['key']);
 		}
-
-		$rawSettings = ExternalModules::getProjectSettingsAsArray($this->PREFIX, self::requireProjectId($pid));
+		$rawSettings = ExternalModules::getSettingsAsArray($this->PREFIX, $pid);
 
 		$subSettings = [];
 		foreach($keys as $key){

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -9,7 +9,6 @@ use ExternalModules\FrameworkVersion2;
 if (!defined(__DIR__)){
 	define(__DIR__, dirname(__FILE__));
 }
-
 require_once __DIR__ . "/AbstractExternalModule.php";
 
 if(PHP_SAPI == 'cli'){
@@ -1071,7 +1070,7 @@ class ExternalModules
 		return self::getSettingsAsArray($moduleDirectoryPrefixes, $projectId);
 	}
 
-	private static function getSettingsAsArray($moduleDirectoryPrefixes, $projectId = NULL)
+	static function getSettingsAsArray($moduleDirectoryPrefixes, $projectId = NULL)
 	{
 		if(empty($moduleDirectoryPrefixes)){
 			throw new Exception('One or more module prefixes must be specified!');


### PR DESCRIPTION
Small fix for oversight in getSubSettings() function inside the AbstractExternalModule class. Previously only called subsettings for project settings, and not system settings.   Changed the function from private to static for getSettingsAsArray in ExternalModules class to allow for this change