### PR TITLE
Timed cron related changes

### DIFF
--- a/docs/official-documentation.md
+++ b/docs/official-documentation.md
@@ -352,10 +352,6 @@ Modules can actually have their own cron jobs that are run at a given interval b
 
 Module cron jobs must be defined in the config.json as seen below, in which each has a `cron_name` (alphanumeric name that is unique within the module), a `cron_description` (text that describes what the cron does), and a `method` (refers to a PHP method in the module class that will be executed when the cron is run). The `cron_frequency` and `cron_max_run_time` must be defined as integers (in units of seconds). The cron_max_run_time refers to the maximum time that the cron job is expected to run (once that time is passed, if the cron is still listed in the state of "processing", it assumes it has failed/crashed and thus will automatically enable it to run again at the next scheduled interval).
 
-A `cron_frequency` and a `cron_max_run_time` can be specified, --OR-- an `cron_hour` and a `cron_minute` can be specified, but not both. In addition to an cron_hour and a cron_minute, a `cron_weekday` (0 [Sundays] - 6 [Saturdays]) or a `cron_monthday` (day of the month) can be specified.
-
-Note: If any of the cron attributes (including cron_frequency/cron_max_run_time or cron_hour/cron_minute, but not both) are missing, it will prevent the module from being enabled.
-
 ``` json
 {
    "crons": [
@@ -372,29 +368,6 @@ Note: If any of the cron attributes (including cron_frequency/cron_max_run_time 
          "method": "some_other_method",
          "cron_frequency": "86400",
          "cron_max_run_time": "1200"
-      },
-      {
-         "cron_name": "cron3",
-         "cron_description": "Cron that runs daily at 1:15 am to do YYY",
-         "method": "some_other_method_3",
-         "cron_hour": 1,
-         "cron_minute": 15
-      },
-      {
-         "cron_name": "cron4",
-         "cron_description": "Cron that runs on Mondays at 2:25 pm to do YYYY",
-         "method": "some_other_method_4",
-         "cron_hour": 14,
-         "cron_minute": 25,
-         "cron_weekday": 1
-      },
-      {
-         "cron_name": "cron5",
-         "cron_description": "Cron that runs on the second of each month at 4:30 pm to do YYYYY",
-         "method": "some_other_method_5",
-         "cron_hour": 16,
-         "cron_minute": 30,
-         "cron_monthday": 2
       }
    ]
 }
@@ -697,28 +670,6 @@ For reference, below is a nearly comprehensive example of the types of things th
          "method": "some_other_method",
          "cron_frequency": "86400",
          "cron_max_run_time": "1200"
-      },
-      {
-         "cron_name": "cron3",
-         "cron_description": "Cron that runs daily at 1:15 am to do YYY",
-         "method": "some_other_method_3",
-         "cron_hour": 1,
-         "cron_minute": 15
-      },
-      {
-         "cron_name": "cron4",
-         "cron_description": "Cron that runs on Mondays at 2:25 pm to do YYYY",
-         "method": "some_other_method_4",
-         "cron_hour": 14,
-         "cron_minute": 25,
-         "cron_weekday": 1
-      },
-      {
-         "cron_name": "cron5",
-         "cron_description": "Cron that runs on the second of each month at 4:30 pm to do YYYYY",
-         "method": "some_other_method_5",
-         "cron_hour": 16,
-         "cron_minute": 30,
       }
    ],
    "compatibility": {


### PR DESCRIPTION
@scottjpearson, this PR aims to take care of the immediate concerns with timed crons so that the testing branch can move to production without having to revert the timed cron changes.  It includes the following changes:

- Previously, long running cron detection started sending emails when the next cron started after the previous cron job had run for at least an hour.  This delay period has been bumped up to 23 hours (as opposed to 24, see the large comment in the code on why).  Also, a limit has been added to make sure only one email is sent per 23 hour period.  This improves the case where a cron scheduled for every minute takes more than 23 hours to run (previously it would start sending emails every minute).
- The timed cron documentation has been removed since we have a few concerns to address before publicly supporting this feature.  I'll create an issue shortly with these details and instructions for re-adding this documentation.

What are your thoughts on the long running cron detection changes?  Do you have any other concerns about the timed cron changes in the testing branch moving to production, and the consortium shortly afterward?  They'd be undocumented and likely not used, so I'm mainly thinking in terms of changing existing functionality.  Thanks!