### PR TITLE
Add REDCap version details to framework version docs

### DIFF
--- a/docs/framework/intro.md
+++ b/docs/framework/intro.md
@@ -1,4 +1,7 @@
 ## External Module Framework - Versioning Introduction
+
+### How to specify the Framework Version for a module
+
 The versioning feature of the **External Module Framework** allows for backward compatibility while the framework changes over time.  New modules should specify the `framework-version` in `config.json` as follows:
  
 ```
@@ -14,8 +17,14 @@ To allow existing modules to remain backward compatible, a new framework version
  
 <br/>
 
-|Framework Versions|
-|------- |
-|[Version 3](v3.md)|
-|[Version 2](v2.md)|
-|[Version 1](v1.md)|
+### Framework versions vs REDCap versions
+
+Specifying a module frame has implications for the minimum REDCap version. A module's config.json should specify a `redcap-version-min` at least as high as that needed to get the framework code it requires.
+
+The frameworks were released in these REDCap versions:
+
+|Framework Versions|First Standard Release|First LTS Release|
+|----------------- |------|-----|
+|[Version 3](v3.md)|9.1.1 |9.1.3|
+|[Version 2](v2.md)|8.11.6|9.1.3|
+|[Version 1](v1.md)|8.0.0 |8.1.2|

--- a/docs/framework/v1.md
+++ b/docs/framework/v1.md
@@ -1,4 +1,7 @@
 ## Framework Version 1
+
+The REDCap External Module framework was first added to REDCap in Standard Release 8.0.0. It first appeared in REDCap LTS at 8.1.2. This version of the External Module framework was rebranded as _Framework Version 1_ when Framework Version 2 was released.
+
 Since each module's main class extends **AbstractExternalModule**, the following built-in methods are available.  They can be called by using **$this** (e.g., `$this->getModuleName()`).
 
 #### Methods

--- a/docs/framework/v2.md
+++ b/docs/framework/v2.md
@@ -1,5 +1,7 @@
 ## Framework Version 2
 
+Framework Version 2 was first added to REDCap in Standard Release 8.11.6. It first appeared in REDCap LTS at 9.1.3.
+
 #### Breaking Changes
 * A `framework` member variable is now automatically added to the module class that will house all future methods.  If any modules previously defined their own `framework` member variable, they will need to be refactored to use a different variable name instead.
 * Calling `$module->framework->getSubSettings()` will return slightly different output than calling `$module->getSubSettings()`.  The framework provided version handles complex nested settings much more accurately, but has some subtle differences preventing full backward compatibility with the method directly on the module class.

--- a/docs/framework/v3.md
+++ b/docs/framework/v3.md
@@ -1,5 +1,7 @@
 ## Framework Version 3
 
+Framework Version 3 was first added to REDCap in Standard Release 9.1.1. It first appeared in REDCap LTS at 9.1.3.
+
 #### Breaking Changes
 * The convention for the **icon** parameter for links specified in config.json has changed to expect [Font Awesome](https://fontawesome.com/icons?d=gallery) icon classes (ex: `fas fa-receipt`) instead of a REDCap image resource name.  A path to an icon filename in your module may also be specified (ex: `images/my-icon.png`).  All link icons will need to be updated when switching to this framework vresion.   
 


### PR DESCRIPTION
This PR addresses Issues #211. I added the REDCap version numbers on the intro.md and the docs specific to each framework. Where to place the new version details is in each is rather subjective. Let me know what you think. 

Also, I bend the truth a bit in intro.md when I say the Framework Version _requires_ a certain REDCap version. I know that strictly speaking one can load newer EM code on older REDCap versions, but do we think that ever happens in a production environment? I chose brevity and being probably right over the verbosity required to be 100% accurate.