### PR TITLE
Fix an incompatibility with IE11 in the Javascript Module Object's interpolate function

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -616,7 +616,7 @@ class ExternalModules
 						// To not replace a placeholder, the first curly can be escaped with a backslash like so: '\{1}' (this will leave '{1}' in the text).
 						// When the an even number of backslashes is before the curly, e.g. '\\{0}' with value x this will result in '\x'.
 						// Placeholder names can be strings (a-Z0-9_), too (need associative array then). 
-						const regex = /(?<all>((?<escape>\\*){|{)(?<index>[\d_A-Za-z]+)(:(?<hint>.*))?})/gm
+						const regex = new RegExp('(?<all>((?<escape>\\*){|{)(?<index>[\d_A-Za-z]+)(:(?<hint>.*))?})', 'gm')
 						var m
 						var result = ''
 						var prevEnd = 0


### PR DESCRIPTION
IE11 doesn't like regexp literals. Using the "old" way of creating the RegExp fixes the problem.

See issue #226