### PR TITLE
Re-enable arrays and object as interpolation sources

### DIFF
--- a/classes/AbstractExternalModule.php
+++ b/classes/AbstractExternalModule.php
@@ -1294,9 +1294,9 @@ class AbstractExternalModule
 				 * @returns {string} The interpolated string.
 				 */
 				module.tt = function (key) {
-					const argArray = Array.prototype.slice.call(arguments)
+					var argArray = Array.prototype.slice.call(arguments)
 					argArray[0] = this._constructLanguageKey(key)
-					const lang = window.ExternalModules.$lang
+					var lang = window.ExternalModules.$lang
 					return lang.tt.apply(lang, argArray)
 				}
 				/**

--- a/classes/AbstractExternalModule.php
+++ b/classes/AbstractExternalModule.php
@@ -1294,10 +1294,9 @@ class AbstractExternalModule
 				 * @returns {string} The interpolated string.
 				 */
 				module.tt = function (key) {
-					var argArray = Array.prototype.slice.call(arguments)
+					const argArray = Array.prototype.slice.call(arguments)
 					argArray[0] = this._constructLanguageKey(key)
-					
-					var lang = window.ExternalModules.$lang
+					const lang = window.ExternalModules.$lang
 					return lang.tt.apply(lang, argArray)
 				}
 				/**

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -577,14 +577,32 @@ class ExternalModules
 							delete this.strings[key]
 					}
 					/**
+					 * Extracts interpolation values from variable function arguments.
+					 * @param {Array} inputs An array of interpolation values (must include the key as first element).
+					 * @returns {Array} An array with the interpolation values.
+					 */
+					lang._getValues = function(inputs) {
+						var values = Array()
+						if (inputs.length > 1) {
+							// If the first value is an array or object, use it instead.
+							if (Array.isArray(inputs[1]) || typeof inputs[1] === 'object' && inputs[1] !== null) {
+								values = inputs[1]
+							}
+							else {
+								values = Array.prototype.slice.call(inputs, 1)
+							}
+						}
+						return values
+					}
+					/**
 					 * Get and interpolate a translation.
 					 * @param {string} key The key for the string.
 					 * Note: Any further arguments after key will be used for interpolation. If the first such argument is an array, it will be used as the interpolation source.
 					 * @returns {string} The interpolated string.
 					 */
 					lang.tt = function(key) {
-						var string = this.get(key)
-						var values = Array.prototype.slice.call(arguments, 1)
+						const string = this.get(key)
+						const values = this._getValues(arguments)
 						return this.interpolate(string, values)
 					}
 					/**
@@ -598,8 +616,8 @@ class ExternalModules
 							console.warn('$lang.interpolate() called with undefined or null.')
 							return ''
 						}
-						// Nothing to do if there are no values or the string is empty.
-						if (values.length == 0 || string.length == 0) {
+						// Is string not a string, or empty? Then there is nothing to do.
+						if (typeof string !== 'string' || string.length == 0) {
 							return string
 						}
 						// Regular expression to find places where replacements need to be done.
@@ -643,7 +661,7 @@ class ExternalModules
 							}
 						}
 						// Add rest of original string.
-						result += string.substr(prevEnd)
+						result += String.prototype.substr.call(string, prevEnd)
 						return result
 					}
 				}

--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -601,8 +601,8 @@ class ExternalModules
 					 * @returns {string} The interpolated string.
 					 */
 					lang.tt = function(key) {
-						const string = this.get(key)
-						const values = this._getValues(arguments)
+						var string = this.get(key)
+						var values = this._getValues(arguments)
 						return this.interpolate(string, values)
 					}
 					/**
@@ -625,7 +625,7 @@ class ExternalModules
 						// To not replace a placeholder, the first curly can be escaped with a backslash like so: '\{1}' (this will leave '{1}' in the text).
 						// When the an even number of backslashes is before the curly, e.g. '\\{0}' with value x this will result in '\x'.
 						// Placeholder names can be strings (a-Z0-9_), too (need associative array then). 
-						const regex = new RegExp('(?<all>((?<escape>\\\\*){|{)(?<index>[\\d_A-Za-z]+)(:(?<hint>.*))?})', 'gm')
+						var regex = new RegExp('(?<all>((?<escape>\\\\*){|{)(?<index>[\\d_A-Za-z]+)(:(?<hint>.*))?})', 'gm')
 						var m
 						var result = ''
 						var prevEnd = 0


### PR DESCRIPTION
Hey @mmcev106 
thanks for the fix of the regexp string. I didn't think about escaping when changing from the literal to the string.

Your other changes, however, prevented the use of arrays and objects as sources for interpolation values. I have reintroduced `_getValues()` to handle this, but only in one place. The JS-`tt()` defined in _AbstractExternalModule_ stays as you proposed (I only changed the `var`s to `const`s to be more explicit).

While testing, I noticed that there was another bug in `interpolate` that would prevent escaping of curly braces when there were no interpolation values. I have changed this, so that the interpolation and excaping logic _always_ runs (provided string is indeed a string).
