### PR TITLE
Replace regexp with custom parser

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -4683,7 +4683,7 @@ class ExternalModules
 				return $query->getStatement()->affected_rows;
 			} else {
 				// "Could not find module ID for prefix '{0}'!"
-				throw new \Exception(self::tt("em_errors_118", $moduleDirectoryPrefix));
+				throw new \Exception(self::tt("em_errors_118", $modulePrefix));
 			}
 		} else {
 			throw new \Exception(self::tt("em_errors_119"));


### PR DESCRIPTION
This fixes an issues in FireFox with the regular expression used to interpolate language strings.

This fix replaces the regular expression (and regex logic) with a custom parser that is implemented the same in both JavaScript and PHP.

Note that the escape charactor for placeholders has been changed from ```\``` (backslash) to ```%``` (percent), to avoid the problems backslash usually brings (needs to be escaped itself, etc.). Since the escape mechanism hasn't been documented (yet), this should not be a problem (I updated the Demo EM which showed this in an example).

I did some limited testing using the Demo EM, but no unit tests have been run. This change should definitely be looked at carefully.