### PR TITLE
Ensure localization is initialized before used

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -165,7 +165,8 @@ class ExternalModules
 
 	private static $configs = array();
 
-	
+	// Holds module prefixes for which language strings have already been added to $lang.
+	private static $localizationInitialized = array();
 
 	# two reserved settings that are there for each project
 	# KEY_VERSION, if present, denotes that the project is enabled system-wide
@@ -957,6 +958,9 @@ class ExternalModules
 	 */
 	public static function initializeLocalizationSupport($prefix, $version) {
 
+		// Have the module's language strings already been loaded?
+		if (in_array($prefix, self::$localizationInitialized)) return;
+
 		global $lang;
 
 		// Get project id if available.
@@ -978,6 +982,9 @@ class ExternalModules
 				$lang[$lang_key] = $val;
 			}
 		}
+
+		// Mark module as initialized.
+		array_push(self::$localizationInitialized, $prefix);
 	}
 
 	/**
@@ -3297,7 +3304,10 @@ class ExternalModules
 		// Add in language settings if available.
 		$config = self::addLanguageSetting($config, $prefix, $version, $pid);
 		// Apply translations to config.
-		if ($translate) $config = self::translateConfig($config, $prefix);
+		if ($translate) {
+			self::initializeLocalizationSupport($prefix, $version);
+			$config = self::translateConfig($config, $prefix);
+		}
 		// Remove hidden config items.
 		self::applyHidden($config);
 


### PR DESCRIPTION
@mmcev106, while enhancing the Localization Demo EM for my upcoming talk this Friday, I noticed that we missed scenario, where translatable strings in `config.json` are used before the respective module is instantiated, and therefore the language strings are missing (and resulting in the _"Language key 'abc' is not defined"_ message). For example, this affected the name of links.

This pull request addresses the issue, by ensuring that initialization (loading of language strings) has indeed happened before config translation. To avoid double work, `initializeLocalizationSupport()` keeps track of the modules already initialized.

It would be nice if this PR could be fast-tracked into the next REDCap release. Thanks.