### PR TITLE
Removed a new features block from v3 since the features are now available in v2 as well

### DIFF
--- a/docs/framework/v3.md
+++ b/docs/framework/v3.md
@@ -8,7 +8,3 @@ Framework Version 3 was first added to REDCap in Standard Release 9.1.1. It firs
 
 * The convention for the **icon** parameter for links specified in config.json has changed to expect [Font Awesome](https://fontawesome.com/icons?d=gallery) icon classes (ex: `fas fa-receipt`) instead of a REDCap image resource name. A path to an icon filename in your module may also be specified (ex: `images/my-icon.png`). All link icons will need to be updated when switching to this framework version.
 * If skipping framework versions, do not forget to review/address the breaking changes from all prior framework versions.
-
-#### New Features
-
-* This framework version introduces **internationalization support** for external modules. Module authors can make their modules "translatable" by including a language file (such as _English.ini_) that contains key/value pairs (exactly as the REDCap core language files). Translatable text is output by the new `tt()` function. Please refer to the [internationalization guide](../i18n-guide.md) for more details.


### PR DESCRIPTION
All new framework methods are now available when using v2 (on whatever REDCap version added each feature).  It seems like this info is already covered elsewhere in the docs (like other methods).  However, I figured I'd run this by you in case you thought we tweak the other docs at all.