### PR TITLE
Localization bug fix 

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -774,7 +774,7 @@ class ExternalModules
 
 		// Get the string - if the key doesn't exist, provide a corresponding message to facilitate debugging.
 		$string = $lang[$key];
-		if ($string == null) {
+		if ($string === null) {
 			$string = self::getLanguageKeyNotDefinedMessage($original_key, $prefix);
 			// Clear interpolation values.
 			$values = array();


### PR DESCRIPTION
PHP loose comparison got me, @mmcev106 . Empty strings are considered null, i.e. `"" == null` is true. Sigh. This leads to false reports of missing language strings when indeed they are there (but empty, which is totally fine).

This PR fixes this issue.