### PR TITLE
Fix translateConfig

### DIFF
--- a/classes/ExternalModules.php
+++ b/classes/ExternalModules.php
@@ -1222,10 +1222,10 @@ class ExternalModules
 	private static function translateConfig(&$config, $prefix) {
 		// Recursively loop through all.
 		foreach ($config as $key => $val) {
-			if (is_array($val) && !in_array($key, self::CONFIG_NONTRANSLATABLE_SECTIONS)) {
+			if (is_array($val) && !in_array($key, self::CONFIG_NONTRANSLATABLE_SECTIONS, true)) {
 				$config[$key] = self::translateConfig($val, $prefix);
 			}
-			else if (in_array($key, self::CONFIG_TRANSLATABLE_KEYS)) {
+			else if (in_array($key, self::CONFIG_TRANSLATABLE_KEYS, true)) {
 				$tt_key = self::CONFIG_TRANSLATABLE_PREFIX.$key;
 				if (isset($config[$tt_key])) {
 					// Set the language key (in case of actual 'true', use the present value as key).


### PR DESCRIPTION
I am not sure I totally understand why this is needed, but the fact is that it is: using strict comparison for the two `in_array` calls.
This fixes the broken unit test mentioned here: https://github.com/vanderbilt/redcap-external-modules/pull/268#issuecomment-593571292