### PR TITLE
Fixed try/catches that weren't working in PHP7

### DIFF
--- a/manager/ajax/send-enable-module-request.php
+++ b/manager/ajax/send-enable-module-request.php
@@ -36,9 +36,12 @@ else {
 				$return_data['error_message'] .= "Mail delivery was unable to be completed.\n";
 			}
 		}
-    } catch (Exception $e) {
+    } catch (Throwable $e) {
         // The problem is likely due to loading the configuration.  Ignore this Exception.
         $return_data['error_message'] .= "Failure loading external module configuration: " . $e->getMessage() . "\n";
-    }
+	} catch (Exception $e) {
+		// The problem is likely due to loading the configuration.  Ignore this Exception.
+		$return_data['error_message'] .= "Failure loading external module configuration: " . $e->getMessage() . "\n";
+	}
 }
 echo json_encode($return_data);

--- a/manager/templates/hooks/control_center.php
+++ b/manager/templates/hooks/control_center.php
@@ -19,12 +19,17 @@ if (!empty($extModLinks)) {
                         $link = $new_link;
                     }
                 }
-            } catch(\Exception $e) {
+            } catch(\Throwable $e) {
                 ExternalModules::sendAdminEmail(
 					//= An exception was thrown when generating control center links
 					ExternalModules::tt("em_errors_78"),
 					$e->__toString(), $prefix);
-            }
+			} catch(\Exception $e) {
+				ExternalModules::sendAdminEmail(
+					//= An exception was thrown when generating control center links
+					ExternalModules::tt("em_errors_78"),
+					$e->__toString(), $prefix);
+			}
 
             ?>
 			items += <?=json_encode(ExternalModules::getLinkIconHtml($module_instance, $link))?>;

--- a/manager/templates/hooks/every_page_top.php
+++ b/manager/templates/hooks/every_page_top.php
@@ -48,6 +48,12 @@ $menu_id = 'projMenuExternalModules';
 						<?php
 					}
 				}
+				catch(\Throwable $e){
+					ExternalModules::sendAdminEmail(
+						//= An exception was thrown when generating links
+						ExternalModules::tt("em_errors_77"), 
+						$e->__toString(), $prefix);
+				}
 				catch(\Exception $e){
 					ExternalModules::sendAdminEmail(
 						//= An exception was thrown when generating links


### PR DESCRIPTION
This didn't end up being as bad as I anticipated, mainly because I think only about a third of the try/catches we have actually needed to catch Throwables as well.  I made a reminder to remove the duplication and change all catches to Throwables to be safe when we drop PHP 5.6 support at the beginning of next year.